### PR TITLE
Fix Netlify build configuration

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
-registry=http://localhost:9092/npm-registry
+# Use the public npm registry so dependency installation works in CI/CD
+registry=https://registry.npmjs.org/

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "npm ci --no-audit --no-fund || npm install --ci --no-audit --no-fund; npm run whereami; npm run prebuild; npm run build"
+  command = "npm ci --no-audit --no-fund || npm install --no-audit --no-fund; npm run whereami; npm run prebuild; npm run build"
   publish = "dist"
 
 [build.environment]

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "prebuild": "node -v && npm -v && pwd && ls -la && (ls -la node_modules/.bin || true) && (npx vite --version || echo 'npx could not find vite')",
+    "prebuild": "node -v && npm -v",
     "whereami": "node -e \"console.log('CWD=',process.cwd())\" && node -e \"try{console.log('pkg=',require('./package.json').name)}catch(e){console.log('no package.json here')}\"",
-    "build": "npx vite build",
-    "dev": "npx vite",
-    "preview": "npx vite preview",
+    "build": "vite build",
+    "dev": "vite",
+    "preview": "vite preview",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit -p tsconfig.app.json"
   },


### PR DESCRIPTION
## Summary
- point npm installs to the public npm registry so CI/CD environments can download dependencies
- simplify build scripts to rely on the locally installed Vite binary instead of invoking npx
- correct the Netlify build command fallback to use a supported npm install flag

## Testing
- not run (network restrictions prevented installing dependencies in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e2b0e3f29c8321abe4620b787bc475