### PR TITLE
Streamline contact section with modern form

### DIFF
--- a/public/arkkitehtisuunnittelu-logo.svg
+++ b/public/arkkitehtisuunnittelu-logo.svg
@@ -1,0 +1,6 @@
+<svg width="128" height="128" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="16" y="16" width="80" height="80" rx="8" stroke="#3E3326" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M44 104V72L64 56L84 72V104" stroke="#3E3326" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M56 104H72" stroke="#3E3326" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M96 32H112V112H32V96" stroke="#3E3326" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/public/konsultointipalvelut-logo.svg
+++ b/public/konsultointipalvelut-logo.svg
@@ -1,0 +1,6 @@
+<svg width="128" height="128" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M64 16C49.6406 16 38 27.6406 38 42C38 50.8186 42.4579 58.5872 49.1577 63.1968C51.0305 64.4927 52.25 66.5951 52.25 68.9006V72.5C52.25 74.9853 50.2353 77 47.75 77H44C40.6863 77 38 79.6863 38 83V88C38 91.3137 40.6863 94 44 94H84C87.3137 94 90 91.3137 90 88V83C90 79.6863 87.3137 77 84 77H80.25C77.7647 77 75.75 74.9853 75.75 72.5V68.9006C75.75 66.5951 76.9695 64.4927 78.8423 63.1968C85.5421 58.5872 90 50.8186 90 42C90 27.6406 78.3594 16 64 16Z" stroke="#3E3326" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M54 104H74" stroke="#3E3326" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M58 112H70" stroke="#3E3326" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M64 94V88" stroke="#3E3326" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/rakennesuunnittelu-logo.svg
+++ b/public/rakennesuunnittelu-logo.svg
@@ -1,0 +1,10 @@
+<svg width="128" height="128" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M20 112H108" stroke="#3E3326" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M36 112V32L60 20H104" stroke="#3E3326" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M60 20V32H104" stroke="#3E3326" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M80 32V72" stroke="#3E3326" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="68" y="72" width="24" height="24" stroke="#3E3326" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M68 84H48V100" stroke="#3E3326" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M92 40L104 32" stroke="#3E3326" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="60" cy="32" r="4" fill="#3E3326"/>
+</svg>

--- a/public/rakennuttajapalvelut-logo.svg
+++ b/public/rakennuttajapalvelut-logo.svg
@@ -1,0 +1,8 @@
+<svg width="128" height="128" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="32" y="20" width="64" height="92" rx="10" stroke="#3E3326" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M48 20V16H80V20" stroke="#3E3326" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M52 44L60 52L76 36" stroke="#3E3326" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M52 68L60 76L76 60" stroke="#3E3326" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M52 92L60 100L68 92" stroke="#3E3326" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M80 96C90.4934 96 99 104.507 99 115V116H29V115C29 104.507 37.5066 96 48 96H80Z" stroke="#3E3326" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,31 @@
-import { Building2, Ruler, Users, Award, Phone, Mail, MapPin } from 'lucide-react';
 import { Link } from 'react-router-dom';
+
+const services = [
+  {
+    title: 'Arkkitehtisuunnittelu',
+    desc: '• Asemapiirustus\n\n• Pohjapiirustus\n\n• Leikkauspiirustukset\n\n• Julkisivukuvat',
+    link: '/arkkitehtisuunnittelu',
+    logo: '/arkkitehtisuunnittelu-logo.svg'
+  },
+  {
+    title: 'Rakennesuunnittelu',
+    desc: '• Turvalliset ja kestävät rakenteet kaikkiin kohteisiin\n\n• Ratkaisut, jotka tukevat arkkitehtisuunnittelua ja helpottavat työmaan toteutusta\n\n• Selkeät ja luotettavat rakennesuunnitelmat, jotka tekevät rakentamisesta sujuvampaa',
+    link: '/rakennesuunnittelu',
+    logo: '/rakennesuunnittelu-logo.svg'
+  },
+  {
+    title: 'Konsultointipalvelut – pähkinänkuoressa',
+    desc: '• Asiantuntevaa tukea rakennushankkeen eri vaiheisiin\n\n• Suunnitelmien arviointi ja kustannusarvioiden laadinta\n\n• Viranomaisasioiden hoitamisen neuvonta\n\n• Ratkaisut asiakkaan tarpeen mukaan\n\n• Päätöksenteon helpottaminen ja projektin selkeyttäminen',
+    link: '/konsultointipalvelut',
+    logo: '/konsultointipalvelut-logo.svg'
+  },
+  {
+    title: 'Rakennuttajapalvelut',
+    desc: '• Vastaavatyönjohtaja\n\n• Pääsuunnittelija\n\n• Rakennushankkeen hallinta alusta loppuun\n\n• Asiakkaan edunvalvonta koko projektin ajan\n\n• Vaivattomampi ja hallitumpi rakennusprosessi',
+    link: '/rakennuttajapalvelut',
+    logo: '/rakennuttajapalvelut-logo.svg'
+  }
+];
 
 function App() {
   return (
@@ -55,18 +81,12 @@ function App() {
       {/* Hero Section */}
       <section className="h-screen flex items-center justify-center px-6">
         <div className="container mx-auto text-center">
-          <h2 className="text-5xl md:text-6xl font-bold mb-6" style={{ color: '#3E3326' }}>
-            Rakennamme Visiosi
+          <h2 className="text-5xl md:text-6xl font-bold mb-4" style={{ color: '#3E3326' }}>
+            Tarkkaa suunnittelua, varmaa valvontaa
           </h2>
-          <p className="text-xl md:text-2xl mb-8 max-w-3xl mx-auto" style={{ color: '#3E3326' }}>
-            Ammattitaitoista rakennussuunnittelua ja arkkitehtuuripalveluita asuin- ja liikekiinteistöihin
+          <p className="text-2xl md:text-3xl font-semibold mb-6 max-w-2xl mx-auto" style={{ color: '#C9972E' }}>
+            Yhdessä teemme unelmastasi totta
           </p>
-          <button
-            className="px-8 py-4 rounded-lg text-white font-semibold text-lg hover:opacity-90 transition-opacity"
-            style={{ backgroundColor: '#C9972E' }}
-          >
-            Aloita Projektisi
-          </button>
         </div>
       </section>
 
@@ -75,16 +95,11 @@ function App() {
         <div className="container mx-auto">
           <h2 className="text-4xl font-bold text-center mb-12 mt-12" style={{ color: '#3E3326' }}>Palvelut</h2>
           <div className="grid md:grid-cols-2 lg:grid-cols-2 gap-8 max-w-6xl mx-auto">
-            {[
-              { title: 'Arkkitehtisuunnittelu', desc: '• Asemapiirustus\n\n• Pohjapiirustus\n\n• Leikkauspiirustukset\n\n• Julkisivukuvat', link: '/arkkitehtisuunnittelu' },
-              { title: 'Rakennesuunnittelu', desc: '• Turvalliset ja kestävät rakenteet kaikkiin kohteisiin\n\n• Ratkaisut, jotka tukevat arkkitehtisuunnittelua ja helpottavat työmaan toteutusta\n\n• Selkeät ja luotettavat rakennesuunnitelmat, jotka tekevät rakentamisesta sujuvampaa', link: '/rakennesuunnittelu' },
-              { title: 'Konsultointipalvelut – pähkinänkuoressa', desc: '• Asiantuntevaa tukea rakennushankkeen eri vaiheisiin\n\n• Suunnitelmien arviointi ja kustannusarvioiden laadinta\n\n• Viranomaisasioiden hoitamisen neuvonta\n\n• Ratkaisut asiakkaan tarpeen mukaan\n\n• Päätöksenteon helpottaminen ja projektin selkeyttäminen', link: '/konsultointipalvelut' },
-              { title: 'Rakennuttajapalvelut', desc: '• Vastaavatyönjohtaja\n\n• Pääsuunnittelija\n\n• Rakennushankkeen hallinta alusta loppuun\n\n• Asiakkaan edunvalvonta koko projektin ajan\n\n• Vaivattomampi ja hallitumpi rakennusprosessi', link: '/rakennuttajapalvelut' }
-            ].map((service, index) => {
+            {services.map((service, index) => {
               const ServiceBox = (
                 <div
                   key={index}
-                  className="p-10 rounded-xl hover:shadow-2xl transition-all duration-300 hover:-translate-y-1 h-full flex flex-col"
+                  className="p-10 rounded-xl hover:shadow-2xl transition-all duration-300 hover:-translate-y-1 h-full flex flex-col relative overflow-hidden"
                   style={{
                     backgroundColor: '#FEF8EB',
                     border: '3px solid #C9972E',
@@ -93,8 +108,21 @@ function App() {
                   }}
                   onClick={() => service.link && window.open(service.link, '_blank')}
                 >
-                  <h3 className="text-xl font-bold mb-8" style={{ color: '#3E3326', fontSize: '1.35rem', lineHeight: '1.5', letterSpacing: '0.01em' }}>{service.title}</h3>
-                  <p style={{
+                  {service.logo && (
+                    <img
+                      src={service.logo}
+                      alt={`${service.title} logo`}
+                      className="absolute -top-6 -right-6 w-36 h-36 opacity-10 select-none pointer-events-none"
+                      style={{ color: '#3E3326' }}
+                    />
+                  )}
+                  <h3
+                    className="text-xl font-bold mb-8 relative z-10"
+                    style={{ color: '#3E3326', fontSize: '1.35rem', lineHeight: '1.5', letterSpacing: '0.01em' }}
+                  >
+                    {service.title}
+                  </h3>
+                  <p className="relative z-10" style={{
                     color: '#3E3326',
                     whiteSpace: 'pre-line',
                     lineHeight: '2',
@@ -157,72 +185,75 @@ function App() {
 
       {/* Contact Section */}
       <section id="contact" className="min-h-screen flex items-center justify-center px-6">
-        <div className="container mx-auto max-w-4xl">
-          <h2 className="text-4xl font-bold text-center mb-16" style={{ color: '#3E3326' }}>Ota Yhteyttä</h2>
-          <div className="grid md:grid-cols-2 gap-12">
-            <div className="space-y-6">
-              <div className="flex items-start space-x-4">
-                <Phone className="w-6 h-6 mt-1" style={{ color: '#C9972E' }} />
-                <div>
-                  <h3 className="font-bold mb-1" style={{ color: '#3E3326' }}>Puhelin</h3>
-                  <p style={{ color: '#3E3326', opacity: 0.8 }}>+358 XX XXX XXXX</p>
-                </div>
-              </div>
-              <div className="flex items-start space-x-4">
-                <Mail className="w-6 h-6 mt-1" style={{ color: '#C9972E' }} />
-                <div>
-                  <h3 className="font-bold mb-1" style={{ color: '#3E3326' }}>Sähköposti</h3>
-                  <p style={{ color: '#3E3326', opacity: 0.8 }}>info@aurinkokuninkan.fi</p>
-                </div>
-              </div>
-              <div className="flex items-start space-x-4">
-                <MapPin className="w-6 h-6 mt-1" style={{ color: '#C9972E' }} />
-                <div>
-                  <h3 className="font-bold mb-1" style={{ color: '#3E3326' }}>Osoite</h3>
-                  <p style={{ color: '#3E3326', opacity: 0.8 }}>Helsinki, Finland</p>
-                </div>
-              </div>
+        <div className="container mx-auto max-w-2xl">
+          <form
+            className="rounded-3xl border shadow-lg p-10 space-y-8"
+            style={{ backgroundColor: '#FEF8EB', borderColor: '#E0D2BF' }}
+          >
+            <div className="space-y-2 text-center">
+              <h2 className="text-4xl font-bold" style={{ color: '#3E3326' }}>
+                Ota yhteyttä
+              </h2>
+              <p className="text-base" style={{ color: '#3E3326', opacity: 0.8 }}>
+                Täytä lomake ja palaamme sinulle pian.
+              </p>
             </div>
-            <form className="space-y-4">
-              <input
-                type="text"
-                placeholder="Nimi"
-                className="w-full px-4 py-3 rounded-lg border-2 focus:outline-none focus:border-opacity-100"
-                style={{
-                  backgroundColor: '#FEF8EB',
-                  borderColor: '#C9972E',
-                  color: '#3E3326'
-                }}
-              />
-              <input
-                type="email"
-                placeholder="Sähköposti"
-                className="w-full px-4 py-3 rounded-lg border-2 focus:outline-none focus:border-opacity-100"
-                style={{
-                  backgroundColor: '#FEF8EB',
-                  borderColor: '#C9972E',
-                  color: '#3E3326'
-                }}
-              />
-              <textarea
-                placeholder="Viesti"
-                rows={4}
-                className="w-full px-4 py-3 rounded-lg border-2 focus:outline-none focus:border-opacity-100"
-                style={{
-                  backgroundColor: '#FEF8EB',
-                  borderColor: '#C9972E',
-                  color: '#3E3326'
-                }}
-              />
-              <button
-                type="submit"
-                className="w-full py-3 rounded-lg text-white font-semibold hover:opacity-90 transition-opacity"
-                style={{ backgroundColor: '#C9972E' }}
-              >
-                Lähetä Viesti
-              </button>
-            </form>
-          </div>
+            <div className="space-y-6">
+              <label className="block text-left">
+                <span className="block text-sm font-semibold mb-2" style={{ color: '#3E3326' }}>
+                  Nimi
+                </span>
+                <input
+                  type="text"
+                  placeholder="Kirjoita koko nimesi"
+                  className="w-full px-4 py-3 rounded-xl border-2 focus:outline-none focus:ring-4 focus:ring-[#C9972E]/20 focus:border-[#C9972E] transition-all"
+                  style={{
+                    backgroundColor: '#FEF8EB',
+                    borderColor: '#E0D2BF',
+                    color: '#3E3326'
+                  }}
+                />
+              </label>
+              <label className="block text-left">
+                <span className="block text-sm font-semibold mb-2" style={{ color: '#3E3326' }}>
+                  Sähköposti
+                </span>
+                <input
+                  type="email"
+                  placeholder="esimerkki@yritys.fi"
+                  className="w-full px-4 py-3 rounded-xl border-2 focus:outline-none focus:ring-4 focus:ring-[#C9972E]/20 focus:border-[#C9972E] transition-all"
+                  style={{
+                    backgroundColor: '#FEF8EB',
+                    borderColor: '#E0D2BF',
+                    color: '#3E3326'
+                  }}
+                />
+              </label>
+              <label className="block text-left">
+                <span className="block text-sm font-semibold mb-2" style={{ color: '#3E3326' }}>
+                  Viesti
+                </span>
+                <textarea
+                  placeholder="Kerro lyhyesti projektistasi ja toiveistasi"
+                  rows={5}
+                  className="w-full px-4 py-3 rounded-xl border-2 focus:outline-none focus:ring-4 focus:ring-[#C9972E]/20 focus:border-[#C9972E] transition-all"
+                  style={{
+                    backgroundColor: '#FEF8EB',
+                    borderColor: '#E0D2BF',
+                    color: '#3E3326',
+                    resize: 'vertical'
+                  }}
+                />
+              </label>
+            </div>
+            <button
+              type="submit"
+              className="w-full py-4 rounded-xl text-lg font-semibold text-white transition-all duration-200 hover:-translate-y-0.5 hover:shadow-xl"
+              style={{ backgroundColor: '#C9972E', boxShadow: '0 12px 24px rgba(201, 151, 46, 0.25)' }}
+            >
+              Lähetä viesti
+            </button>
+          </form>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- replace the contact section layout with a single, centered form card for inquiries
- style the form fields and button with brand-aligned colors and modern focus states for clarity

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e52f64f6cc8321aaa7428eaee1b9f8