### PR TITLE
Add dedicated contact page with navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,13 +66,13 @@ function App() {
               >
                 Projektit
               </Link>
-              <a
-                href="#contact"
+              <Link
+                to="/yhteystiedot"
                 className="px-6 py-3 rounded-lg text-lg font-medium transition-all duration-300 hover:bg-[#C9972E]"
                 style={{ color: '#3E3326' }}
               >
                 Yhteystiedot
-              </a>
+              </Link>
             </div>
           </div>
         </nav>

--- a/src/YhteystiedotPage.tsx
+++ b/src/YhteystiedotPage.tsx
@@ -1,0 +1,181 @@
+import { ArrowLeft, Mail, MapPin, Phone, Clock, MessageCircle } from 'lucide-react';
+
+function YhteystiedotPage() {
+  return (
+    <div className="min-h-screen" style={{ backgroundColor: '#FEF8EB' }}>
+      {/* Header */}
+      <header
+        className="fixed top-0 w-full z-50 backdrop-blur-sm border-b"
+        style={{ backgroundColor: 'rgba(254, 248, 235, 0.95)', borderColor: '#C9972E' }}
+      >
+        <nav className="px-6 py-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-4">
+              <img src="/logo.svg" alt="Aurinkokuninkaan Logo" className="h-16 w-16 object-contain" />
+              <span className="text-lg font-semibold" style={{ color: '#3E3326' }}>
+                Aurinkokuninkaan Suunnittelu- ja Rakennuspalvelu Oy
+              </span>
+            </div>
+            <a
+              href="/"
+              className="flex items-center gap-2 px-6 py-3 rounded-lg text-lg font-medium transition-all duration-300 hover:bg-[#C9972E]"
+              style={{ color: '#3E3326' }}
+            >
+              <ArrowLeft className="w-5 h-5" />
+              Takaisin etusivulle
+            </a>
+          </div>
+        </nav>
+      </header>
+
+      <main className="px-6 pt-32 pb-24">
+        <div className="container mx-auto max-w-5xl">
+          <section className="text-center mb-16">
+            <p className="uppercase tracking-[0.4em] text-sm font-semibold mb-6" style={{ color: '#C9972E' }}>
+              Ota yhteyttä
+            </p>
+            <h1 className="text-5xl font-bold mb-6" style={{ color: '#3E3326' }}>
+              Yhdessä teemme seuraavasta projektistasi onnistuneen
+            </h1>
+            <p className="text-lg max-w-3xl mx-auto" style={{ color: '#3E3326', lineHeight: '1.9' }}>
+              Olipa kyseessä uusi rakennusprojekti tai nykyisen hankkeen tukeminen, Tami Takala auttaa sinua
+              varmistamaan, että kokonaisuus pysyy hallittuna ja tavoitteet saavutetaan. Valitse itsellesi sopivin
+              yhteydenottotapa, niin palaamme asiaan nopeasti.
+            </p>
+          </section>
+
+          <section className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr]">
+            <div
+              className="rounded-3xl border shadow-2xl p-10 space-y-8"
+              style={{ backgroundColor: '#FEF8EB', borderColor: '#E0D2BF', boxShadow: '0 25px 45px rgba(201, 151, 46, 0.18)' }}
+            >
+              <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-6">
+                <div className="text-left space-y-2">
+                  <h2 className="text-3xl font-semibold" style={{ color: '#3E3326' }}>
+                    Tami Takala
+                  </h2>
+                  <p className="text-base uppercase tracking-[0.3em]" style={{ color: '#C9972E' }}>
+                    Yrittäjä, rakennusalan asiantuntija
+                  </p>
+                </div>
+                <div
+                  className="h-28 w-28 rounded-full border-4 flex items-center justify-center"
+                  style={{ borderColor: '#C9972E', backgroundColor: 'rgba(201, 151, 46, 0.08)' }}
+                >
+                  <span className="text-4xl font-semibold" style={{ color: '#C9972E' }}>TT</span>
+                </div>
+              </div>
+
+              <div className="grid gap-6 md:grid-cols-2">
+                {[
+                  {
+                    icon: <Phone className="w-6 h-6" />,
+                    title: 'Puhelin',
+                    value: '+358 40 123 4567',
+                    helper: 'Parhaiten tavoitat arkisin klo 8–17',
+                    href: 'tel:+358401234567'
+                  },
+                  {
+                    icon: <Mail className="w-6 h-6" />,
+                    title: 'Sähköposti',
+                    value: 'tami.takala@aurinkokuningas.fi',
+                    helper: 'Vastaamme viesteihin yhden arkipäivän sisällä',
+                    href: 'mailto:tami.takala@aurinkokuningas.fi'
+                  },
+                  {
+                    icon: <MapPin className="w-6 h-6" />,
+                    title: 'Toimialue',
+                    value: 'Pohjanmaa ja koko Suomi sopimuksen mukaan',
+                    helper: 'Joustavat ratkaisut myös etäpalavereilla'
+                  },
+                  {
+                    icon: <Clock className="w-6 h-6" />,
+                    title: 'Aukiolo',
+                    value: 'Ma–Pe 8.00–17.00',
+                    helper: 'Sovi tapaaminen joustavasti tarpeesi mukaan'
+                  }
+                ].map((item, index) => (
+                  <a
+                    key={index}
+                    href={item.href}
+                    className={`group p-6 rounded-2xl border transition-all duration-300 ${
+                      item.href
+                        ? 'hover:-translate-y-1 hover:shadow-xl hover:border-[#C9972E]' 
+                        : 'cursor-default'
+                    }`}
+                    style={{ backgroundColor: '#FEF8EB', borderColor: '#E0D2BF', color: '#3E3326' }}
+                  >
+                    <div
+                      className="flex items-center justify-center h-12 w-12 rounded-full mb-4 group-hover:scale-110 transition-transform"
+                      style={{ backgroundColor: 'rgba(201, 151, 46, 0.12)', color: '#C9972E' }}
+                    >
+                      {item.icon}
+                    </div>
+                    <h3 className="text-lg font-semibold mb-2" style={{ color: '#3E3326' }}>
+                      {item.title}
+                    </h3>
+                    <p className="text-base leading-relaxed" style={{ color: '#3E3326' }}>
+                      {item.value}
+                    </p>
+                    {item.helper && (
+                      <p className="text-sm mt-3" style={{ color: '#3E3326', opacity: 0.75 }}>
+                        {item.helper}
+                      </p>
+                    )}
+                  </a>
+                ))}
+              </div>
+            </div>
+
+            <div className="space-y-8">
+              <div
+                className="rounded-3xl border shadow-lg p-8"
+                style={{ backgroundColor: '#FEF8EB', borderColor: '#E0D2BF', boxShadow: '0 16px 30px rgba(201, 151, 46, 0.12)' }}
+              >
+                <h2 className="text-2xl font-semibold mb-4" style={{ color: '#3E3326' }}>
+                  Suunnitellaan seuraava askel yhdessä
+                </h2>
+                <p className="text-base leading-relaxed mb-6" style={{ color: '#3E3326' }}>
+                  Kerro lyhyesti projektistasi tai haasteestasi. Räätälöimme palvelun tarpeidesi mukaan ja varmistamme,
+                  että jokainen vaihe pysyy aikataulussa ja budjetissa.
+                </p>
+                <a
+                  href="mailto:tami.takala@aurinkokuningas.fi"
+                  className="w-full inline-flex items-center justify-center gap-2 py-4 rounded-xl text-lg font-semibold transition-all duration-200 hover:-translate-y-0.5 hover:shadow-xl"
+                  style={{ backgroundColor: '#C9972E', color: '#FEF8EB', boxShadow: '0 12px 24px rgba(201, 151, 46, 0.25)' }}
+                >
+                  <MessageCircle className="w-5 h-5" />
+                  Lähetä sähköposti
+                </a>
+              </div>
+
+              <div
+                className="rounded-3xl border p-8 space-y-6"
+                style={{ backgroundColor: 'rgba(201, 151, 46, 0.08)', borderColor: 'rgba(201, 151, 46, 0.3)' }}
+              >
+                <h3 className="text-xl font-semibold" style={{ color: '#3E3326' }}>
+                  Miten voimme auttaa?
+                </h3>
+                <ul className="space-y-3 text-base" style={{ color: '#3E3326' }}>
+                  {[
+                    'Rakennushankkeen kokonaisvaltainen suunnittelu ja koordinointi',
+                    'Pää- ja vastaavan työnjohtajan palvelut eri kohteisiin',
+                    'Rakenteiden turvallisuuden ja kustannustehokkuuden varmistaminen',
+                    'Asiantunteva neuvonta viranomaisasioissa ja lupaprosesseissa'
+                  ].map((item, index) => (
+                    <li key={index} className="flex items-start gap-3">
+                      <span className="mt-2 h-2 w-2 rounded-full" style={{ backgroundColor: '#C9972E' }} />
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </section>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+export default YhteystiedotPage;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import RakennesuunnitteluPage from './RakennesuunnitteluPage.tsx';
 import RakennuttajapalvelutPage from './RakennuttajapalvelutPage.tsx';
 import KonsultointipalvelutPage from './KonsultointipalvelutPage.tsx';
 import ProjektitPage from './ProjektitPage.tsx';
+import YhteystiedotPage from './YhteystiedotPage.tsx';
 import './index.css';
 
 createRoot(document.getElementById('root')!).render(
@@ -19,6 +20,7 @@ createRoot(document.getElementById('root')!).render(
         <Route path="/rakennuttajapalvelut" element={<RakennuttajapalvelutPage />} />
         <Route path="/konsultointipalvelut" element={<KonsultointipalvelutPage />} />
         <Route path="/projektit" element={<ProjektitPage />} />
+        <Route path="/yhteystiedot" element={<YhteystiedotPage />} />
       </Routes>
     </BrowserRouter>
   </StrictMode>


### PR DESCRIPTION
## Summary
- add a dedicated Yhteystiedot page highlighting Tami Takala's contact information and services
- link the site header's contact button to the new page for consistent navigation
- register the page in the router so it can be accessed via /yhteystiedot

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e53ca1c9b88321bf8100b870e3d1fd