### PR TITLE
Improve mobile responsiveness across the site

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,6 @@
-import { Link } from 'react-router-dom';
+import { type MouseEvent, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { Menu, X } from 'lucide-react';
 
 const services = [
   {
@@ -28,47 +30,121 @@ const services = [
 ];
 
 function App() {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const navigate = useNavigate();
+
+  const handleServiceNavigation = (link?: string) => {
+    if (!link) {
+      return;
+    }
+    if (link.startsWith('/')) {
+      navigate(link);
+      return;
+    }
+    window.location.href = link;
+  };
+
+  const handleAnchorClick = (event: MouseEvent<HTMLAnchorElement>, targetId: string) => {
+    event.preventDefault();
+    const element = document.getElementById(targetId);
+    if (element) {
+      element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      setIsMenuOpen(false);
+    }
+  };
+
   return (
     <div className="min-h-screen" style={{ backgroundColor: '#FEF8EB' }}>
       {/* Header */}
       <header className="fixed top-0 w-full z-50 backdrop-blur-sm border-b" style={{ backgroundColor: 'rgba(254, 248, 235, 0.95)', borderColor: '#C9972E' }}>
-        <nav className="px-6 py-4">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-4">
+        <nav className="px-4 sm:px-6 py-4">
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex flex-1 items-center gap-4">
               <img
                 src="/logo.svg"
                 alt="Aurinkokuninkan Logo"
-                className="h-16 w-16 object-contain"
+                className="h-14 w-14 object-contain flex-shrink-0"
               />
-              <span className="text-lg font-semibold" style={{ color: '#3E3326' }}>
+              <span className="text-sm sm:text-base md:text-lg font-semibold leading-snug" style={{ color: '#3E3326' }}>
                 Aurinkokuninkaan Suunnittelu- ja Rakennuspalvelu Oy
               </span>
             </div>
-            <div className="hidden md:flex space-x-4">
+            <div className="hidden md:flex space-x-2 lg:space-x-4">
               <a
                 href="#services"
-                className="px-6 py-3 rounded-lg text-lg font-medium transition-all duration-300 hover:bg-[#C9972E]"
+                onClick={(event) => handleAnchorClick(event, 'services')}
+                className="px-4 lg:px-6 py-2.5 lg:py-3 rounded-lg text-base lg:text-lg font-medium transition-all duration-300 hover:bg-[#C9972E]"
                 style={{ color: '#3E3326' }}
               >
                 Palvelut
               </a>
               <a
                 href="#about"
-                className="px-6 py-3 rounded-lg text-lg font-medium transition-all duration-300 hover:bg-[#C9972E]"
+                onClick={(event) => handleAnchorClick(event, 'about')}
+                className="px-4 lg:px-6 py-2.5 lg:py-3 rounded-lg text-base lg:text-lg font-medium transition-all duration-300 hover:bg-[#C9972E]"
                 style={{ color: '#3E3326' }}
               >
                 Minusta
               </a>
               <Link
                 to="/projektit"
-                className="px-6 py-3 rounded-lg text-lg font-medium transition-all duration-300 hover:bg-[#C9972E]"
+                className="px-4 lg:px-6 py-2.5 lg:py-3 rounded-lg text-base lg:text-lg font-medium transition-all duration-300 hover:bg-[#C9972E]"
                 style={{ color: '#3E3326' }}
               >
                 Projektit
               </Link>
               <Link
                 to="/yhteystiedot"
-                className="px-6 py-3 rounded-lg text-lg font-medium transition-all duration-300 hover:bg-[#C9972E]"
+                className="px-4 lg:px-6 py-2.5 lg:py-3 rounded-lg text-base lg:text-lg font-medium transition-all duration-300 hover:bg-[#C9972E]"
+                style={{ color: '#3E3326' }}
+              >
+                Yhteystiedot
+              </Link>
+            </div>
+            <button
+              type="button"
+              className="md:hidden inline-flex items-center justify-center rounded-lg border border-[#C9972E]/30 p-2 text-[#3E3326] transition-colors hover:bg-[#C9972E]/10"
+              aria-label="Avaa valikko"
+              aria-expanded={isMenuOpen}
+              onClick={() => setIsMenuOpen((prev) => !prev)}
+            >
+              {isMenuOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
+            </button>
+          </div>
+          <div
+            className={`md:hidden transition-all duration-300 ease-in-out ${
+              isMenuOpen ? 'max-h-96 opacity-100 mt-4' : 'pointer-events-none max-h-0 opacity-0'
+            }`}
+          >
+            <div className="flex flex-col gap-2 rounded-2xl border p-4 shadow-lg" style={{ backgroundColor: '#FEF8EB', borderColor: '#E0D2BF' }}>
+              <a
+                href="#services"
+                onClick={(event) => handleAnchorClick(event, 'services')}
+                className="rounded-xl px-4 py-3 text-base font-medium transition-colors hover:bg-[#C9972E]/15"
+                style={{ color: '#3E3326' }}
+              >
+                Palvelut
+              </a>
+              <a
+                href="#about"
+                onClick={(event) => handleAnchorClick(event, 'about')}
+                className="rounded-xl px-4 py-3 text-base font-medium transition-colors hover:bg-[#C9972E]/15"
+                style={{ color: '#3E3326' }}
+              >
+                Minusta
+              </a>
+              <Link
+                to="/projektit"
+                onClick={() => setIsMenuOpen(false)}
+                className="rounded-xl px-4 py-3 text-base font-medium transition-colors hover:bg-[#C9972E]/15"
+                style={{ color: '#3E3326' }}
+              >
+                Projektit
+              </Link>
+              <Link
+                to="/yhteystiedot"
+                onClick={() => setIsMenuOpen(false)}
+                className="rounded-xl px-4 py-3 text-base font-medium transition-colors hover:bg-[#C9972E]/15"
                 style={{ color: '#3E3326' }}
               >
                 Yhteystiedot
@@ -79,57 +155,84 @@ function App() {
       </header>
 
       {/* Hero Section */}
-      <section className="h-screen flex items-center justify-center px-6">
-        <div className="container mx-auto text-center">
-          <h2 className="text-5xl md:text-6xl font-bold mb-4" style={{ color: '#3E3326' }}>
+      <section className="min-h-screen flex items-center justify-center px-4 sm:px-6 pt-32 pb-16">
+        <div className="container mx-auto text-center space-y-6">
+          <h2 className="text-4xl sm:text-5xl md:text-6xl font-bold" style={{ color: '#3E3326' }}>
             Tarkkaa suunnittelua, varmaa valvontaa
           </h2>
-          <p className="text-2xl md:text-3xl font-semibold mb-6 max-w-2xl mx-auto" style={{ color: '#C9972E' }}>
+          <p className="text-xl sm:text-2xl md:text-3xl font-semibold max-w-2xl mx-auto" style={{ color: '#C9972E' }}>
             Yhdessä teemme unelmastasi totta
           </p>
         </div>
       </section>
 
       {/* Services Section */}
-      <section id="services" className="min-h-screen flex items-center justify-center px-6" style={{ backgroundColor: 'rgba(201, 151, 46, 0.1)' }}>
+      <section
+        id="services"
+        className="scroll-mt-28 md:scroll-mt-40 flex items-center justify-center px-4 sm:px-6 py-16"
+        style={{ backgroundColor: 'rgba(201, 151, 46, 0.1)' }}
+      >
         <div className="container mx-auto">
-          <h2 className="text-4xl font-bold text-center mb-12 mt-12" style={{ color: '#3E3326' }}>Palvelut</h2>
-          <div className="grid md:grid-cols-2 lg:grid-cols-2 gap-8 max-w-6xl mx-auto">
+          <h2 className="text-3xl sm:text-4xl font-bold text-center mb-10 sm:mb-12" style={{ color: '#3E3326' }}>
+            Palvelut
+          </h2>
+          <div className="grid gap-6 sm:gap-8 md:grid-cols-2 max-w-6xl mx-auto">
             {services.map((service, index) => {
               const ServiceBox = (
                 <div
                   key={index}
-                  className="p-10 rounded-xl hover:shadow-2xl transition-all duration-300 hover:-translate-y-1 h-full flex flex-col relative overflow-hidden"
+                  className="group rounded-xl border-2" 
                   style={{
                     backgroundColor: '#FEF8EB',
-                    border: '3px solid #C9972E',
-                    boxShadow: '0 4px 6px rgba(201, 151, 46, 0.1)',
+                    border: '2px solid #C9972E',
+                    boxShadow: '0 4px 12px rgba(201, 151, 46, 0.15)',
                     cursor: service.link ? 'pointer' : 'default'
                   }}
-                  onClick={() => service.link && window.open(service.link, '_blank')}
+                  onClick={() => handleServiceNavigation(service.link)}
+                  role={service.link ? 'link' : undefined}
+                  tabIndex={service.link ? 0 : -1}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault();
+                      handleServiceNavigation(service.link);
+                    }
+                  }}
                 >
                   {service.logo && (
                     <img
                       src={service.logo}
                       alt={`${service.title} logo`}
-                      className="absolute -top-6 -right-6 w-36 h-36 opacity-10 select-none pointer-events-none"
+                      className="absolute -top-8 -right-8 w-32 h-32 sm:w-36 sm:h-36 opacity-10 select-none pointer-events-none"
                       style={{ color: '#3E3326' }}
                     />
                   )}
-                  <h3
-                    className="text-xl font-bold mb-8 relative z-10"
-                    style={{ color: '#3E3326', fontSize: '1.35rem', lineHeight: '1.5', letterSpacing: '0.01em' }}
-                  >
-                    {service.title}
-                  </h3>
-                  <p className="relative z-10" style={{
-                    color: '#3E3326',
-                    whiteSpace: 'pre-line',
-                    lineHeight: '2',
-                    fontSize: '1rem',
-                    fontWeight: '400',
-                    letterSpacing: '0.01em'
-                  }}>{service.desc}</p>
+                  <div className="relative z-10 flex h-full flex-col gap-6 p-6 sm:p-8 lg:p-10">
+                    <h3
+                      className="text-xl sm:text-2xl font-bold"
+                      style={{ color: '#3E3326', lineHeight: '1.4', letterSpacing: '0.01em' }}
+                    >
+                      {service.title}
+                    </h3>
+                    <p
+                      className="text-base sm:text-lg"
+                      style={{
+                        color: '#3E3326',
+                        whiteSpace: 'pre-line',
+                        lineHeight: '1.8',
+                        fontWeight: 400,
+                        letterSpacing: '0.01em'
+                      }}
+                    >
+                      {service.desc}
+                    </p>
+                    {service.link && (
+                      <span
+                        className="mt-auto inline-flex items-center text-sm font-semibold uppercase tracking-widest text-[#C9972E] transition-transform duration-200 group-hover:translate-x-1"
+                      >
+                        Tutustu palveluun →
+                      </span>
+                    )}
+                  </div>
                 </div>
               );
               return ServiceBox;
@@ -139,62 +242,67 @@ function App() {
       </section>
 
       {/* About Section */}
-        <section id="about" className="min-h-screen flex items-center justify-center px-6 py-16">
-          <div className="container mx-auto max-w-6xl">
-            <div className="text-center mb-16">
-              <h2 className="text-4xl font-bold" style={{ color: '#3E3326' }}>Minusta</h2>
-            </div>
-            <div className="grid gap-12 lg:grid-cols-[minmax(0,320px)_1fr] items-start">
-              <div
-                className="rounded-3xl border shadow-lg p-8 flex flex-col items-center text-center"
-                style={{ backgroundColor: '#FEF8EB', borderColor: '#E0D2BF', color: '#3E3326' }}
-              >
-                <div className="w-36 h-36 rounded-full overflow-hidden mb-6 border-4" style={{ borderColor: '#C9972E' }}>
-                  <img
-                    src="/IMG_1785.jpg"
-                    alt="Tami Takala"
-                    className="w-full h-full object-cover"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <h3 className="text-2xl font-semibold">Tami Takala</h3>
-                  <div className="space-y-1 text-base" style={{ color: '#3E3326', opacity: 0.85 }}>
-                    <p className="font-medium" style={{ opacity: 0.9 }}>Yrittäjä</p>
-                    <p>+358 XX XXX XXXX</p>
-                    <p>kristian@aurinkokuningas.fi</p>
-                  </div>
+      <section
+        id="about"
+        className="scroll-mt-28 md:scroll-mt-40 flex items-center justify-center px-4 sm:px-6 py-16"
+      >
+        <div className="container mx-auto max-w-6xl">
+          <div className="text-center mb-12 sm:mb-16">
+            <h2 className="text-3xl sm:text-4xl font-bold" style={{ color: '#3E3326' }}>
+              Minusta
+            </h2>
+          </div>
+          <div className="grid gap-10 lg:gap-12 lg:grid-cols-[minmax(0,320px)_1fr] items-start">
+            <div
+              className="rounded-3xl border shadow-lg p-8 flex flex-col items-center text-center"
+              style={{ backgroundColor: '#FEF8EB', borderColor: '#E0D2BF', color: '#3E3326' }}
+            >
+              <div className="w-32 h-32 sm:w-36 sm:h-36 rounded-full overflow-hidden mb-6 border-4" style={{ borderColor: '#C9972E' }}>
+                <img
+                  src="/IMG_1785.jpg"
+                  alt="Tami Takala"
+                  className="w-full h-full object-cover"
+                />
+              </div>
+              <div className="space-y-2">
+                <h3 className="text-xl sm:text-2xl font-semibold">Tami Takala</h3>
+                <div className="space-y-1 text-sm sm:text-base" style={{ color: '#3E3326', opacity: 0.85 }}>
+                  <p className="font-medium" style={{ opacity: 0.9 }}>Yrittäjä</p>
+                  <p>+358 XX XXX XXXX</p>
+                  <p>kristian@aurinkokuningas.fi</p>
                 </div>
               </div>
-              <div className="space-y-6 text-lg leading-relaxed">
-                <div className="rounded-3xl border p-8 shadow-sm" style={{ backgroundColor: '#FEF8EB', borderColor: '#E0D2BF' }}>
-                  <p style={{ color: '#3E3326' }}>
-                    Taustani ulottuu käytännön rakennustöistä työnjohtoon ja projektinhallintaan, joten ymmärrän rakentamista
-                    monesta näkökulmasta. Työskentelyssäni yhdistyvät asiantuntemus, käytännön kokemus ja halu tehdä rakennusprojekteista
-                    asiakkaille selkeitä ja sujuvia. Johdan projekteja ihmisläheisesti, kuunnellen asiakkaiden tarpeita ja etsien
-                    ratkaisuja, jotka tuovat arvoa sekä lyhyellä että pitkällä tähtäimellä.
-                  </p>
-                  <p style={{ color: '#3E3326' }}>
-                    Uskon, että vahva vuorovaikutus ja läpinäkyvä viestintä ovat onnistuneiden hankkeiden kulmakivet. Siksi pidän
-                    asiakkaani ajan tasalla jokaisessa projektin vaiheessa ja varmistun siitä, että lopputulos täyttää sovitut tavoitteet.
-                  </p>
-                </div>
+            </div>
+            <div className="space-y-6 text-base sm:text-lg leading-relaxed">
+              <div className="rounded-3xl border p-6 sm:p-8 shadow-sm" style={{ backgroundColor: '#FEF8EB', borderColor: '#E0D2BF' }}>
+                <p style={{ color: '#3E3326' }}>
+                  Taustani ulottuu käytännön rakennustöistä työnjohtoon ja projektinhallintaan, joten ymmärrän rakentamista
+                  monesta näkökulmasta. Työskentelyssäni yhdistyvät asiantuntemus, käytännön kokemus ja halu tehdä rakennusprojekteista
+                  asiakkaille selkeitä ja sujuvia. Johdan projekteja ihmisläheisesti, kuunnellen asiakkaiden tarpeita ja etsien
+                  ratkaisuja, jotka tuovat arvoa sekä lyhyellä että pitkällä tähtäimellä.
+                </p>
+                <p style={{ color: '#3E3326' }}>
+                  Uskon, että vahva vuorovaikutus ja läpinäkyvä viestintä ovat onnistuneiden hankkeiden kulmakivet. Siksi pidän
+                  asiakkaani ajan tasalla jokaisessa projektin vaiheessa ja varmistun siitä, että lopputulos täyttää sovitut tavoitteet.
+                </p>
               </div>
             </div>
           </div>
-        </section>
+        </div>
+      </section>
 
       {/* Contact Section */}
-      <section id="contact" className="min-h-screen flex items-center justify-center px-6">
+      <section id="contact" className="scroll-mt-28 md:scroll-mt-40 flex items-center justify-center px-4 sm:px-6 py-16">
         <div className="container mx-auto max-w-2xl">
           <form
-            className="rounded-3xl border shadow-lg p-10 space-y-8"
+            className="rounded-3xl border shadow-lg p-6 sm:p-8 lg:p-10 space-y-8"
             style={{ backgroundColor: '#FEF8EB', borderColor: '#E0D2BF' }}
           >
             <div className="space-y-2 text-center">
-              <h2 className="text-4xl font-bold" style={{ color: '#3E3326' }}>
+              <h2 className="text-3xl sm:text-4xl font-bold" style={{ color: '#3E3326' }}>
                 Ota yhteyttä
               </h2>
-              <p className="text-base" style={{ color: '#3E3326', opacity: 0.8 }}>
+              <p className="text-sm sm:text-base" style={{ color: '#3E3326', opacity: 0.8 }}>
                 Täytä lomake ja palaamme sinulle pian.
               </p>
             </div>
@@ -248,7 +356,7 @@ function App() {
             </div>
             <button
               type="submit"
-              className="w-full py-4 rounded-xl text-lg font-semibold text-white transition-all duration-200 hover:-translate-y-0.5 hover:shadow-xl"
+              className="w-full py-3 sm:py-4 rounded-xl text-base sm:text-lg font-semibold text-white transition-all duration-200 hover:-translate-y-0.5 hover:shadow-xl"
               style={{ backgroundColor: '#C9972E', boxShadow: '0 12px 24px rgba(201, 151, 46, 0.25)' }}
             >
               Lähetä viesti

--- a/src/ArkkitehtisuunnitteluPage.tsx
+++ b/src/ArkkitehtisuunnitteluPage.tsx
@@ -5,22 +5,21 @@ function ArkkitehtisuunnitteluPage() {
     <div className="min-h-screen" style={{ backgroundColor: '#FEF8EB' }}>
       {/* Header */}
       <header className="fixed top-0 w-full z-50 backdrop-blur-sm border-b" style={{ backgroundColor: 'rgba(254, 248, 235, 0.95)', borderColor: '#C9972E' }}>
-        <nav className="px-6 py-4">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-4">
+        <nav className="px-4 sm:px-6 py-4">
+          <div className="flex flex-col gap-4 text-center sm:flex-row sm:items-center sm:justify-between sm:text-left">
+            <div className="flex items-center justify-center gap-4 sm:justify-start">
               <img
                 src="/logo.svg"
                 alt="Aurinkokuninkan Logo"
-                className="h-16 w-16 object-contain"
+                className="h-12 w-12 sm:h-14 sm:w-14 object-contain"
               />
-              <span className="text-lg font-semibold" style={{ color: '#3E3326' }}>
+              <span className="text-base font-semibold sm:text-lg" style={{ color: '#3E3326' }}>
                 Aurinkokuninkaan Suunnittelu- ja Rakennuspalvelu Oy
               </span>
             </div>
             <a
               href="/"
-              className="flex items-center gap-2 px-6 py-3 rounded-lg text-lg font-medium transition-all duration-300 hover:bg-[#C9972E]"
-              style={{ color: '#3E3326' }}
+              className="inline-flex items-center justify-center gap-2 rounded-lg border border-[#C9972E]/40 px-4 py-2.5 text-sm font-medium text-[#3E3326] transition-colors hover:bg-[#C9972E]/15 sm:text-base"
             >
               <ArrowLeft className="w-5 h-5" />
               Takaisin
@@ -30,22 +29,22 @@ function ArkkitehtisuunnitteluPage() {
       </header>
 
       {/* Content Section */}
-      <section className="min-h-screen flex items-center justify-center px-6 pt-32 pb-24">
+      <section className="px-4 sm:px-6 pt-28 pb-16">
         <div className="container mx-auto max-w-4xl">
-          <h1 className="text-5xl font-bold text-center mb-16 mt-8" style={{ color: '#3E3326' }}>
+          <h1 className="mt-20 text-center text-3xl font-bold sm:mt-12 sm:text-4xl md:text-5xl" style={{ color: '#3E3326' }}>
             Arkkitehtisuunnittelu
           </h1>
 
           <div
-            className="p-12 rounded-2xl space-y-8"
+            className="mt-10 rounded-2xl border-2 p-6 sm:p-8 lg:p-12 space-y-6 sm:space-y-8"
             style={{
               backgroundColor: '#FEF8EB',
-              border: '3px solid #C9972E',
-              boxShadow: '0 10px 30px rgba(201, 151, 46, 0.15)'
+              border: '2px solid #C9972E',
+              boxShadow: '0 10px 30px rgba(201, 151, 46, 0.12)'
             }}
           >
             <p
-              className="text-lg leading-relaxed"
+              className="text-base sm:text-lg leading-relaxed"
               style={{
                 color: '#3E3326',
                 lineHeight: '2',
@@ -59,7 +58,7 @@ function ArkkitehtisuunnitteluPage() {
             </p>
 
             <p
-              className="text-lg leading-relaxed"
+              className="text-base sm:text-lg leading-relaxed"
               style={{
                 color: '#3E3326',
                 lineHeight: '2',
@@ -74,7 +73,7 @@ function ArkkitehtisuunnitteluPage() {
             </p>
 
             <p
-              className="text-lg leading-relaxed"
+              className="text-base sm:text-lg leading-relaxed"
               style={{
                 color: '#3E3326',
                 lineHeight: '2',
@@ -87,12 +86,9 @@ function ArkkitehtisuunnitteluPage() {
               tarpeita että esteettisiä toiveita.
             </p>
 
-            <div
-              className="mt-12 pt-8 border-t-2"
-              style={{ borderColor: '#C9972E' }}
-            >
+            <div className="mt-8 sm:mt-12 pt-6 sm:pt-8 border-t-2" style={{ borderColor: '#C9972E' }}>
               <h2
-                className="text-2xl font-bold mb-6"
+                className="text-xl sm:text-2xl font-bold mb-4 sm:mb-6"
                 style={{ color: '#3E3326' }}
               >
                 Palvelut sisältävät
@@ -106,7 +102,7 @@ function ArkkitehtisuunnitteluPage() {
                 ].map((item, index) => (
                   <li
                     key={index}
-                    className="flex items-center gap-3 text-lg"
+                    className="flex items-center gap-3 text-base sm:text-lg"
                     style={{ color: '#3E3326' }}
                   >
                     <span

--- a/src/KonsultointipalvelutPage.tsx
+++ b/src/KonsultointipalvelutPage.tsx
@@ -5,22 +5,21 @@ function KonsultointipalvelutPage() {
     <div className="min-h-screen" style={{ backgroundColor: '#FEF8EB' }}>
       {/* Header */}
       <header className="fixed top-0 w-full z-50 backdrop-blur-sm border-b" style={{ backgroundColor: 'rgba(254, 248, 235, 0.95)', borderColor: '#C9972E' }}>
-        <nav className="px-6 py-4">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-4">
+        <nav className="px-4 sm:px-6 py-4">
+          <div className="flex flex-col gap-4 text-center sm:flex-row sm:items-center sm:justify-between sm:text-left">
+            <div className="flex items-center justify-center gap-4 sm:justify-start">
               <img
                 src="/logo.svg"
                 alt="Aurinkokuninkan Logo"
-                className="h-16 w-16 object-contain"
+                className="h-12 w-12 sm:h-14 sm:w-14 object-contain"
               />
-              <span className="text-lg font-semibold" style={{ color: '#3E3326' }}>
+              <span className="text-base font-semibold sm:text-lg" style={{ color: '#3E3326' }}>
                 Aurinkokuninkaan Suunnittelu- ja Rakennuspalvelu Oy
               </span>
             </div>
             <a
               href="/"
-              className="flex items-center gap-2 px-6 py-3 rounded-lg text-lg font-medium transition-all duration-300 hover:bg-[#C9972E]"
-              style={{ color: '#3E3326' }}
+              className="inline-flex items-center justify-center gap-2 rounded-lg border border-[#C9972E]/40 px-4 py-2.5 text-sm font-medium text-[#3E3326] transition-colors hover:bg-[#C9972E]/15 sm:text-base"
             >
               <ArrowLeft className="w-5 h-5" />
               Takaisin
@@ -30,22 +29,22 @@ function KonsultointipalvelutPage() {
       </header>
 
       {/* Content Section */}
-      <section className="min-h-screen flex items-center justify-center px-6 pt-32 pb-24">
+      <section className="px-4 sm:px-6 pt-28 pb-16">
         <div className="container mx-auto max-w-4xl">
-          <h1 className="text-5xl font-bold text-center mb-16 mt-8" style={{ color: '#3E3326' }}>
+          <h1 className="mt-20 text-center text-3xl font-bold sm:mt-12 sm:text-4xl md:text-5xl" style={{ color: '#3E3326' }}>
             Konsultointipalvelut
           </h1>
 
           <div
-            className="p-12 rounded-2xl space-y-8"
+            className="mt-10 rounded-2xl border-2 p-6 sm:p-8 lg:p-12 space-y-6 sm:space-y-8"
             style={{
               backgroundColor: '#FEF8EB',
-              border: '3px solid #C9972E',
-              boxShadow: '0 10px 30px rgba(201, 151, 46, 0.15)'
+              border: '2px solid #C9972E',
+              boxShadow: '0 10px 30px rgba(201, 151, 46, 0.12)'
             }}
           >
             <p
-              className="text-lg leading-relaxed"
+              className="text-base sm:text-lg leading-relaxed"
               style={{
                 color: '#3E3326',
                 lineHeight: '2',
@@ -57,7 +56,7 @@ function KonsultointipalvelutPage() {
             </p>
 
             <p
-              className="text-lg leading-relaxed"
+              className="text-base sm:text-lg leading-relaxed"
               style={{
                 color: '#3E3326',
                 lineHeight: '2',
@@ -69,11 +68,11 @@ function KonsultointipalvelutPage() {
             </p>
 
             <div
-              className="mt-12 pt-8 border-t-2"
+              className="mt-8 sm:mt-12 pt-6 sm:pt-8 border-t-2"
               style={{ borderColor: '#C9972E' }}
             >
               <h2
-                className="text-2xl font-bold mb-6"
+                className="text-xl sm:text-2xl font-bold mb-4 sm:mb-6"
                 style={{ color: '#3E3326' }}
               >
                 Palvelut sisältävät
@@ -88,7 +87,7 @@ function KonsultointipalvelutPage() {
                 ].map((item, index) => (
                   <li
                     key={index}
-                    className="flex items-center gap-3 text-lg"
+                    className="flex items-center gap-3 text-base sm:text-lg"
                     style={{ color: '#3E3326' }}
                   >
                     <span

--- a/src/ProjektitPage.tsx
+++ b/src/ProjektitPage.tsx
@@ -54,22 +54,21 @@ function ProjektitPage() {
     <div className="min-h-screen" style={{ backgroundColor: '#FEF8EB' }}>
       {/* Header */}
       <header className="fixed top-0 w-full z-50 backdrop-blur-sm border-b" style={{ backgroundColor: 'rgba(254, 248, 235, 0.95)', borderColor: '#C9972E' }}>
-        <nav className="px-6 py-4">
-          <div className="flex items-center justify-between">
-            <Link to="/" className="flex items-center gap-4 hover:opacity-80 transition-opacity">
+        <nav className="px-4 sm:px-6 py-4">
+          <div className="flex flex-col gap-4 text-center sm:flex-row sm:items-center sm:justify-between sm:text-left">
+            <Link to="/" className="flex items-center justify-center gap-4 transition-opacity hover:opacity-80 sm:justify-start">
               <img
                 src="/logo.svg"
                 alt="Aurinkokuninkan Logo"
-                className="h-16 w-16 object-contain"
+                className="h-12 w-12 sm:h-14 sm:w-14 object-contain"
               />
-              <span className="text-lg font-semibold" style={{ color: '#3E3326' }}>
+              <span className="text-base font-semibold sm:text-lg" style={{ color: '#3E3326' }}>
                 Aurinkokuninkaan Suunnittelu- ja Rakennuspalvelu Oy
               </span>
             </Link>
             <Link
               to="/"
-              className="flex items-center gap-2 px-6 py-3 rounded-lg text-lg font-medium transition-all duration-300 hover:bg-[#C9972E]"
-              style={{ color: '#3E3326' }}
+              className="inline-flex items-center justify-center gap-2 rounded-lg border border-[#C9972E]/40 px-4 py-2.5 text-sm font-medium text-[#3E3326] transition-colors hover:bg-[#C9972E]/15 sm:text-base"
             >
               <ArrowLeft className="w-5 h-5" />
               Takaisin
@@ -79,30 +78,30 @@ function ProjektitPage() {
       </header>
 
       {/* Hero Section */}
-      <section className="pt-32 pb-16 px-6" style={{ backgroundColor: 'rgba(201, 151, 46, 0.1)' }}>
+      <section className="pt-28 pb-14 px-4 sm:px-6" style={{ backgroundColor: 'rgba(201, 151, 46, 0.1)' }}>
         <div className="container mx-auto max-w-6xl">
-          <h1 className="text-5xl font-bold text-center mb-6" style={{ color: '#3E3326' }}>
+          <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold text-center mb-6" style={{ color: '#3E3326' }}>
             Projektit
           </h1>
-          <p className="text-xl text-center max-w-3xl mx-auto" style={{ color: '#3E3326', opacity: 0.9 }}>
+          <p className="text-base sm:text-lg md:text-xl text-center max-w-3xl mx-auto" style={{ color: '#3E3326', opacity: 0.9 }}>
             Tutustu toteutettuihin projekteihimme, jotka kuvaavat osaamistamme ja sitoutumistamme laatuun
           </p>
         </div>
       </section>
 
       {/* Projects Grid */}
-      <section className="py-16 px-6">
+      <section className="py-14 px-4 sm:px-6">
         <div className="container mx-auto max-w-7xl">
-          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
+          <div className="grid gap-6 sm:gap-8 md:grid-cols-2 lg:grid-cols-3">
             {projects.map((project, index) => (
               <div
                 key={index}
-                className="rounded-xl overflow-hidden hover:shadow-2xl transition-all duration-300 hover:-translate-y-2 flex flex-col"
+                className="flex flex-col overflow-hidden rounded-xl border-2 transition-all duration-300 hover:-translate-y-2 hover:shadow-2xl"
                 style={{ backgroundColor: '#FEF8EB', border: '2px solid #C9972E' }}
               >
                 {index === 0 && (
                   <div
-                    className="h-56 flex items-center justify-center overflow-hidden"
+                    className="h-48 sm:h-56 flex items-center justify-center overflow-hidden"
                     style={{ backgroundColor: 'rgba(201, 151, 46, 0.15)' }}
                   >
                     <img
@@ -116,26 +115,30 @@ function ProjektitPage() {
                     />
                   </div>
                 )}
-                <div className="p-6 flex flex-col flex-grow">
-                  <h3 className="text-2xl font-bold mb-2" style={{ color: '#3E3326' }}>{project.title}</h3>
-                  <p className="text-sm font-semibold mb-4" style={{ color: '#C9972E' }}>{project.category}</p>
+                <div className="flex flex-grow flex-col gap-4 p-5 sm:p-6">
+                  <div>
+                    <h3 className="text-xl sm:text-2xl font-bold" style={{ color: '#3E3326' }}>{project.title}</h3>
+                    <p className="text-xs font-semibold uppercase tracking-widest text-[#C9972E] sm:text-sm">
+                      {project.category}
+                    </p>
+                  </div>
 
-                  <div className="space-y-2 mb-4">
-                    <div className="flex items-center gap-2 text-sm" style={{ color: '#3E3326', opacity: 0.8 }}>
+                  <div className="space-y-2">
+                    <div className="flex items-center gap-2 text-xs sm:text-sm" style={{ color: '#3E3326', opacity: 0.8 }}>
                       <MapPin className="w-4 h-4" style={{ color: '#C9972E' }} />
                       <span>{project.location}</span>
                     </div>
-                    <div className="flex items-center gap-2 text-sm" style={{ color: '#3E3326', opacity: 0.8 }}>
+                    <div className="flex items-center gap-2 text-xs sm:text-sm" style={{ color: '#3E3326', opacity: 0.8 }}>
                       <Calendar className="w-4 h-4" style={{ color: '#C9972E' }} />
                       <span>{project.year}</span>
                     </div>
-                    <div className="flex items-center gap-2 text-sm" style={{ color: '#3E3326', opacity: 0.8 }}>
+                    <div className="flex items-center gap-2 text-xs sm:text-sm" style={{ color: '#3E3326', opacity: 0.8 }}>
                       <Ruler className="w-4 h-4" style={{ color: '#C9972E' }} />
                       <span>{project.area}</span>
                     </div>
                   </div>
 
-                  <p className="text-sm mb-4" style={{ color: '#3E3326', opacity: 0.85, lineHeight: '1.6' }}>
+                  <p className="text-sm" style={{ color: '#3E3326', opacity: 0.85, lineHeight: '1.7' }}>
                     {project.description}
                   </p>
 
@@ -143,7 +146,7 @@ function ProjektitPage() {
                     <h4 className="text-sm font-semibold mb-2" style={{ color: '#3E3326' }}>Ominaisuudet:</h4>
                     <ul className="space-y-1">
                       {project.features.map((feature, idx) => (
-                        <li key={idx} className="text-sm flex items-start gap-2" style={{ color: '#3E3326', opacity: 0.8 }}>
+                        <li key={idx} className="flex items-start gap-2 text-sm" style={{ color: '#3E3326', opacity: 0.8 }}>
                           <span style={{ color: '#C9972E' }}>•</span>
                           <span>{feature}</span>
                         </li>
@@ -158,17 +161,17 @@ function ProjektitPage() {
       </section>
 
       {/* Call to Action */}
-      <section className="py-16 px-6" style={{ backgroundColor: 'rgba(201, 151, 46, 0.1)' }}>
+      <section className="py-16 px-4 sm:px-6" style={{ backgroundColor: 'rgba(201, 151, 46, 0.1)' }}>
         <div className="container mx-auto max-w-4xl text-center">
-          <h2 className="text-3xl font-bold mb-6" style={{ color: '#3E3326' }}>
+          <h2 className="text-2xl sm:text-3xl font-bold mb-6" style={{ color: '#3E3326' }}>
             Aloita Oma Projektisi
           </h2>
-          <p className="text-lg mb-8" style={{ color: '#3E3326', opacity: 0.9 }}>
+          <p className="text-base sm:text-lg mb-8" style={{ color: '#3E3326', opacity: 0.9 }}>
             Haluatko toteuttaa oman rakennusprojektisi? Ota yhteyttä ja keskustellaan, miten voimme auttaa visiosi toteutumisessa.
           </p>
           <Link
             to="/#contact"
-            className="inline-block px-8 py-4 rounded-lg text-white font-semibold text-lg hover:opacity-90 transition-opacity"
+            className="inline-block rounded-lg px-6 py-3 text-sm font-semibold text-white transition-opacity hover:opacity-90 sm:px-8 sm:py-4 sm:text-lg"
             style={{ backgroundColor: '#C9972E' }}
           >
             Ota Yhteyttä

--- a/src/RakennesuunnitteluPage.tsx
+++ b/src/RakennesuunnitteluPage.tsx
@@ -5,22 +5,21 @@ function RakennesuunnitteluPage() {
     <div className="min-h-screen" style={{ backgroundColor: '#FEF8EB' }}>
       {/* Header */}
       <header className="fixed top-0 w-full z-50 backdrop-blur-sm border-b" style={{ backgroundColor: 'rgba(254, 248, 235, 0.95)', borderColor: '#C9972E' }}>
-        <nav className="px-6 py-4">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-4">
+        <nav className="px-4 sm:px-6 py-4">
+          <div className="flex flex-col gap-4 text-center sm:flex-row sm:items-center sm:justify-between sm:text-left">
+            <div className="flex items-center justify-center gap-4 sm:justify-start">
               <img
                 src="/logo.svg"
                 alt="Aurinkokuninkan Logo"
-                className="h-16 w-16 object-contain"
+                className="h-12 w-12 sm:h-14 sm:w-14 object-contain"
               />
-              <span className="text-lg font-semibold" style={{ color: '#3E3326' }}>
+              <span className="text-base font-semibold sm:text-lg" style={{ color: '#3E3326' }}>
                 Aurinkokuninkaan Suunnittelu- ja Rakennuspalvelu Oy
               </span>
             </div>
             <a
               href="/"
-              className="flex items-center gap-2 px-6 py-3 rounded-lg text-lg font-medium transition-all duration-300 hover:bg-[#C9972E]"
-              style={{ color: '#3E3326' }}
+              className="inline-flex items-center justify-center gap-2 rounded-lg border border-[#C9972E]/40 px-4 py-2.5 text-sm font-medium text-[#3E3326] transition-colors hover:bg-[#C9972E]/15 sm:text-base"
             >
               <ArrowLeft className="w-5 h-5" />
               Takaisin
@@ -30,22 +29,22 @@ function RakennesuunnitteluPage() {
       </header>
 
       {/* Content Section */}
-      <section className="min-h-screen flex items-center justify-center px-6 pt-32 pb-24">
+      <section className="px-4 sm:px-6 pt-28 pb-16">
         <div className="container mx-auto max-w-4xl">
-          <h1 className="text-5xl font-bold text-center mb-16 mt-8" style={{ color: '#3E3326' }}>
+          <h1 className="mt-20 text-center text-3xl font-bold sm:mt-12 sm:text-4xl md:text-5xl" style={{ color: '#3E3326' }}>
             Rakennesuunnittelu
           </h1>
 
           <div
-            className="p-12 rounded-2xl space-y-8"
+            className="mt-10 rounded-2xl border-2 p-6 sm:p-8 lg:p-12 space-y-6 sm:space-y-8"
             style={{
               backgroundColor: '#FEF8EB',
-              border: '3px solid #C9972E',
-              boxShadow: '0 10px 30px rgba(201, 151, 46, 0.15)'
+              border: '2px solid #C9972E',
+              boxShadow: '0 10px 30px rgba(201, 151, 46, 0.12)'
             }}
           >
             <p
-              className="text-lg leading-relaxed"
+              className="text-base sm:text-lg leading-relaxed"
               style={{
                 color: '#3E3326',
                 lineHeight: '2',
@@ -57,7 +56,7 @@ function RakennesuunnitteluPage() {
             </p>
 
             <p
-              className="text-lg leading-relaxed"
+              className="text-base sm:text-lg leading-relaxed"
               style={{
                 color: '#3E3326',
                 lineHeight: '2',
@@ -69,7 +68,7 @@ function RakennesuunnitteluPage() {
             </p>
 
             <p
-              className="text-lg leading-relaxed"
+              className="text-base sm:text-lg leading-relaxed"
               style={{
                 color: '#3E3326',
                 lineHeight: '2',

--- a/src/RakennuttajapalvelutPage.tsx
+++ b/src/RakennuttajapalvelutPage.tsx
@@ -5,22 +5,21 @@ function RakennuttajapalvelutPage() {
     <div className="min-h-screen" style={{ backgroundColor: '#FEF8EB' }}>
       {/* Header */}
       <header className="fixed top-0 w-full z-50 backdrop-blur-sm border-b" style={{ backgroundColor: 'rgba(254, 248, 235, 0.95)', borderColor: '#C9972E' }}>
-        <nav className="px-6 py-4">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-4">
+        <nav className="px-4 sm:px-6 py-4">
+          <div className="flex flex-col gap-4 text-center sm:flex-row sm:items-center sm:justify-between sm:text-left">
+            <div className="flex items-center justify-center gap-4 sm:justify-start">
               <img
                 src="/logo.svg"
                 alt="Aurinkokuninkan Logo"
-                className="h-16 w-16 object-contain"
+                className="h-12 w-12 sm:h-14 sm:w-14 object-contain"
               />
-              <span className="text-lg font-semibold" style={{ color: '#3E3326' }}>
+              <span className="text-base font-semibold sm:text-lg" style={{ color: '#3E3326' }}>
                 Aurinkokuninkaan Suunnittelu- ja Rakennuspalvelu Oy
               </span>
             </div>
             <a
               href="/"
-              className="flex items-center gap-2 px-6 py-3 rounded-lg text-lg font-medium transition-all duration-300 hover:bg-[#C9972E]"
-              style={{ color: '#3E3326' }}
+              className="inline-flex items-center justify-center gap-2 rounded-lg border border-[#C9972E]/40 px-4 py-2.5 text-sm font-medium text-[#3E3326] transition-colors hover:bg-[#C9972E]/15 sm:text-base"
             >
               <ArrowLeft className="w-5 h-5" />
               Takaisin
@@ -30,22 +29,22 @@ function RakennuttajapalvelutPage() {
       </header>
 
       {/* Content Section */}
-      <section className="min-h-screen flex items-center justify-center px-6 pt-32 pb-24">
+      <section className="px-4 sm:px-6 pt-28 pb-16">
         <div className="container mx-auto max-w-4xl">
-          <h1 className="text-5xl font-bold text-center mb-16 mt-8" style={{ color: '#3E3326' }}>
+          <h1 className="mt-20 text-center text-3xl font-bold sm:mt-12 sm:text-4xl md:text-5xl" style={{ color: '#3E3326' }}>
             Rakennuttajapalvelut
           </h1>
 
           <div
-            className="p-12 rounded-2xl space-y-8"
+            className="mt-10 rounded-2xl border-2 p-6 sm:p-8 lg:p-12 space-y-6 sm:space-y-8"
             style={{
               backgroundColor: '#FEF8EB',
-              border: '3px solid #C9972E',
-              boxShadow: '0 10px 30px rgba(201, 151, 46, 0.15)'
+              border: '2px solid #C9972E',
+              boxShadow: '0 10px 30px rgba(201, 151, 46, 0.12)'
             }}
           >
             <p
-              className="text-lg leading-relaxed"
+              className="text-base sm:text-lg leading-relaxed"
               style={{
                 color: '#3E3326',
                 lineHeight: '2',
@@ -57,7 +56,7 @@ function RakennuttajapalvelutPage() {
             </p>
 
             <p
-              className="text-lg leading-relaxed"
+              className="text-base sm:text-lg leading-relaxed"
               style={{
                 color: '#3E3326',
                 lineHeight: '2',
@@ -69,7 +68,7 @@ function RakennuttajapalvelutPage() {
             </p>
 
             <p
-              className="text-lg leading-relaxed"
+              className="text-base sm:text-lg leading-relaxed"
               style={{
                 color: '#3E3326',
                 lineHeight: '2',
@@ -81,11 +80,11 @@ function RakennuttajapalvelutPage() {
             </p>
 
             <div
-              className="mt-12 pt-8 border-t-2"
+              className="mt-8 sm:mt-12 pt-6 sm:pt-8 border-t-2"
               style={{ borderColor: '#C9972E' }}
             >
               <h2
-                className="text-2xl font-bold mb-6"
+                className="text-xl sm:text-2xl font-bold mb-4 sm:mb-6"
                 style={{ color: '#3E3326' }}
               >
                 Palvelut sisältävät
@@ -100,7 +99,7 @@ function RakennuttajapalvelutPage() {
                 ].map((item, index) => (
                   <li
                     key={index}
-                    className="flex items-center gap-3 text-lg"
+                    className="flex items-center gap-3 text-base sm:text-lg"
                     style={{ color: '#3E3326' }}
                   >
                     <span

--- a/src/YhteystiedotPage.tsx
+++ b/src/YhteystiedotPage.tsx
@@ -8,18 +8,17 @@ function YhteystiedotPage() {
         className="fixed top-0 w-full z-50 backdrop-blur-sm border-b"
         style={{ backgroundColor: 'rgba(254, 248, 235, 0.95)', borderColor: '#C9972E' }}
       >
-        <nav className="px-6 py-4">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-4">
-              <img src="/logo.svg" alt="Aurinkokuninkaan Logo" className="h-16 w-16 object-contain" />
-              <span className="text-lg font-semibold" style={{ color: '#3E3326' }}>
+        <nav className="px-4 sm:px-6 py-4">
+          <div className="flex flex-col gap-4 text-center sm:flex-row sm:items-center sm:justify-between sm:text-left">
+            <div className="flex items-center justify-center gap-4 sm:justify-start">
+              <img src="/logo.svg" alt="Aurinkokuninkaan Logo" className="h-12 w-12 sm:h-14 sm:w-14 object-contain" />
+              <span className="text-base font-semibold sm:text-lg" style={{ color: '#3E3326' }}>
                 Aurinkokuninkaan Suunnittelu- ja Rakennuspalvelu Oy
               </span>
             </div>
             <a
               href="/"
-              className="flex items-center gap-2 px-6 py-3 rounded-lg text-lg font-medium transition-all duration-300 hover:bg-[#C9972E]"
-              style={{ color: '#3E3326' }}
+              className="inline-flex items-center justify-center gap-2 rounded-lg border border-[#C9972E]/40 px-4 py-2.5 text-sm font-medium text-[#3E3326] transition-colors hover:bg-[#C9972E]/15 sm:text-base"
             >
               <ArrowLeft className="w-5 h-5" />
               Takaisin etusivulle
@@ -28,16 +27,16 @@ function YhteystiedotPage() {
         </nav>
       </header>
 
-      <main className="px-6 pt-32 pb-24">
+      <main className="px-4 sm:px-6 pt-28 pb-16">
         <div className="container mx-auto max-w-5xl">
-          <section className="text-center mb-16">
-            <p className="uppercase tracking-[0.4em] text-sm font-semibold mb-6" style={{ color: '#C9972E' }}>
+          <section className="text-center mb-14 sm:mb-16">
+            <p className="uppercase tracking-[0.35em] text-xs sm:text-sm font-semibold mb-5" style={{ color: '#C9972E' }}>
               Ota yhteyttä
             </p>
-            <h1 className="text-5xl font-bold mb-6" style={{ color: '#3E3326' }}>
+            <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-6" style={{ color: '#3E3326' }}>
               Yhdessä teemme seuraavasta projektistasi onnistuneen
             </h1>
-            <p className="text-lg max-w-3xl mx-auto" style={{ color: '#3E3326', lineHeight: '1.9' }}>
+            <p className="text-base sm:text-lg max-w-3xl mx-auto" style={{ color: '#3E3326', lineHeight: '1.9' }}>
               Olipa kyseessä uusi rakennusprojekti tai nykyisen hankkeen tukeminen, Tami Takala auttaa sinua
               varmistamaan, että kokonaisuus pysyy hallittuna ja tavoitteet saavutetaan. Valitse itsellesi sopivin
               yhteydenottotapa, niin palaamme asiaan nopeasti.
@@ -46,27 +45,27 @@ function YhteystiedotPage() {
 
           <section className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr]">
             <div
-              className="rounded-3xl border shadow-2xl p-10 space-y-8"
+              className="rounded-3xl border shadow-2xl p-6 sm:p-8 lg:p-10 space-y-8"
               style={{ backgroundColor: '#FEF8EB', borderColor: '#E0D2BF', boxShadow: '0 25px 45px rgba(201, 151, 46, 0.18)' }}
             >
-              <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-6">
+              <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
                 <div className="text-left space-y-2">
-                  <h2 className="text-3xl font-semibold" style={{ color: '#3E3326' }}>
+                  <h2 className="text-2xl sm:text-3xl font-semibold" style={{ color: '#3E3326' }}>
                     Tami Takala
                   </h2>
-                  <p className="text-base uppercase tracking-[0.3em]" style={{ color: '#C9972E' }}>
+                  <p className="text-xs sm:text-sm uppercase tracking-[0.25em]" style={{ color: '#C9972E' }}>
                     Yrittäjä, rakennusalan asiantuntija
                   </p>
                 </div>
                 <div
-                  className="h-28 w-28 rounded-full border-4 flex items-center justify-center"
+                  className="h-24 w-24 sm:h-28 sm:w-28 rounded-full border-4 flex items-center justify-center"
                   style={{ borderColor: '#C9972E', backgroundColor: 'rgba(201, 151, 46, 0.08)' }}
                 >
-                  <span className="text-4xl font-semibold" style={{ color: '#C9972E' }}>TT</span>
+                  <span className="text-3xl sm:text-4xl font-semibold" style={{ color: '#C9972E' }}>TT</span>
                 </div>
               </div>
 
-              <div className="grid gap-6 md:grid-cols-2">
+              <div className="grid gap-4 sm:gap-6 md:grid-cols-2">
                 {[
                   {
                     icon: <Phone className="w-6 h-6" />,
@@ -98,27 +97,27 @@ function YhteystiedotPage() {
                   <a
                     key={index}
                     href={item.href}
-                    className={`group p-6 rounded-2xl border transition-all duration-300 ${
+                    className={`group rounded-2xl border p-5 transition-all duration-300 sm:p-6 ${
                       item.href
-                        ? 'hover:-translate-y-1 hover:shadow-xl hover:border-[#C9972E]' 
+                        ? 'hover:-translate-y-1 hover:shadow-xl hover:border-[#C9972E]'
                         : 'cursor-default'
                     }`}
                     style={{ backgroundColor: '#FEF8EB', borderColor: '#E0D2BF', color: '#3E3326' }}
                   >
                     <div
-                      className="flex items-center justify-center h-12 w-12 rounded-full mb-4 group-hover:scale-110 transition-transform"
+                      className="mb-4 flex h-12 w-12 items-center justify-center rounded-full transition-transform group-hover:scale-110"
                       style={{ backgroundColor: 'rgba(201, 151, 46, 0.12)', color: '#C9972E' }}
                     >
                       {item.icon}
                     </div>
-                    <h3 className="text-lg font-semibold mb-2" style={{ color: '#3E3326' }}>
+                    <h3 className="text-base sm:text-lg font-semibold mb-2" style={{ color: '#3E3326' }}>
                       {item.title}
                     </h3>
-                    <p className="text-base leading-relaxed" style={{ color: '#3E3326' }}>
+                    <p className="text-sm sm:text-base leading-relaxed" style={{ color: '#3E3326' }}>
                       {item.value}
                     </p>
                     {item.helper && (
-                      <p className="text-sm mt-3" style={{ color: '#3E3326', opacity: 0.75 }}>
+                      <p className="mt-3 text-xs sm:text-sm" style={{ color: '#3E3326', opacity: 0.75 }}>
                         {item.helper}
                       </p>
                     )}
@@ -129,19 +128,19 @@ function YhteystiedotPage() {
 
             <div className="space-y-8">
               <div
-                className="rounded-3xl border shadow-lg p-8"
+                className="rounded-3xl border shadow-lg p-6 sm:p-8"
                 style={{ backgroundColor: '#FEF8EB', borderColor: '#E0D2BF', boxShadow: '0 16px 30px rgba(201, 151, 46, 0.12)' }}
               >
-                <h2 className="text-2xl font-semibold mb-4" style={{ color: '#3E3326' }}>
+                <h2 className="text-xl sm:text-2xl font-semibold mb-4" style={{ color: '#3E3326' }}>
                   Suunnitellaan seuraava askel yhdessä
                 </h2>
-                <p className="text-base leading-relaxed mb-6" style={{ color: '#3E3326' }}>
+                <p className="text-sm sm:text-base leading-relaxed mb-6" style={{ color: '#3E3326' }}>
                   Kerro lyhyesti projektistasi tai haasteestasi. Räätälöimme palvelun tarpeidesi mukaan ja varmistamme,
                   että jokainen vaihe pysyy aikataulussa ja budjetissa.
                 </p>
                 <a
                   href="mailto:tami.takala@aurinkokuningas.fi"
-                  className="w-full inline-flex items-center justify-center gap-2 py-4 rounded-xl text-lg font-semibold transition-all duration-200 hover:-translate-y-0.5 hover:shadow-xl"
+                  className="inline-flex w-full items-center justify-center gap-2 rounded-xl py-3 text-base font-semibold transition-all duration-200 hover:-translate-y-0.5 hover:shadow-xl sm:py-4 sm:text-lg"
                   style={{ backgroundColor: '#C9972E', color: '#FEF8EB', boxShadow: '0 12px 24px rgba(201, 151, 46, 0.25)' }}
                 >
                   <MessageCircle className="w-5 h-5" />
@@ -150,13 +149,13 @@ function YhteystiedotPage() {
               </div>
 
               <div
-                className="rounded-3xl border p-8 space-y-6"
+                className="rounded-3xl border p-6 sm:p-8 space-y-5"
                 style={{ backgroundColor: 'rgba(201, 151, 46, 0.08)', borderColor: 'rgba(201, 151, 46, 0.3)' }}
               >
-                <h3 className="text-xl font-semibold" style={{ color: '#3E3326' }}>
+                <h3 className="text-lg sm:text-xl font-semibold" style={{ color: '#3E3326' }}>
                   Miten voimme auttaa?
                 </h3>
-                <ul className="space-y-3 text-base" style={{ color: '#3E3326' }}>
+                <ul className="space-y-3 text-sm sm:text-base" style={{ color: '#3E3326' }}>
                   {[
                     'Rakennushankkeen kokonaisvaltainen suunnittelu ja koordinointi',
                     'Pää- ja vastaavan työnjohtajan palvelut eri kohteisiin',
@@ -164,7 +163,7 @@ function YhteystiedotPage() {
                     'Asiantunteva neuvonta viranomaisasioissa ja lupaprosesseissa'
                   ].map((item, index) => (
                     <li key={index} className="flex items-start gap-3">
-                      <span className="mt-2 h-2 w-2 rounded-full" style={{ backgroundColor: '#C9972E' }} />
+                      <span className="mt-2 h-2 w-2 flex-shrink-0 rounded-full" style={{ backgroundColor: '#C9972E' }} />
                       <span>{item}</span>
                     </li>
                   ))}


### PR DESCRIPTION
## Summary
- add a mobile navigation drawer and responsive spacing to the landing page
- tune typography, spacing, and card layouts on service detail, projects, and contact pages for smaller screens
- ensure section offsets and call-to-action elements render comfortably on mobile devices

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e558f418bc8321be41bc82d41c51fb