### PR TITLE
Ensure service navigation resets scroll position

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
-import { StrictMode } from 'react';
+import { StrictMode, useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
 import App from './App.tsx';
 import ArkkitehtisuunnitteluPage from './ArkkitehtisuunnitteluPage.tsx';
 import RakennesuunnitteluPage from './RakennesuunnitteluPage.tsx';
@@ -10,9 +10,20 @@ import ProjektitPage from './ProjektitPage.tsx';
 import YhteystiedotPage from './YhteystiedotPage.tsx';
 import './index.css';
 
+function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'auto' });
+  }, [pathname]);
+
+  return null;
+}
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>
+      <ScrollToTop />
       <Routes>
         <Route path="/" element={<App />} />
         <Route path="/arkkitehtisuunnittelu" element={<ArkkitehtisuunnitteluPage />} />


### PR DESCRIPTION
## Summary
- add a ScrollToTop helper that scrolls the window to the top whenever the route changes
- render ScrollToTop inside the BrowserRouter so service pages open from the top of the viewport

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ef92a5b87483219cbe15df3205218c