### PR TITLE
Ensure service detail pages return to services section

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
-import { type MouseEvent, useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { type MouseEvent, useEffect, useState } from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { Menu, X } from 'lucide-react';
 
 const services = [
@@ -16,7 +16,7 @@ const services = [
     logo: '/rakennesuunnittelu-logo.svg'
   },
   {
-    title: 'Konsultointipalvelut – pähkinänkuoressa',
+    title: 'Konsultointipalvelut',
     desc: '• Asiantuntevaa tukea rakennushankkeen eri vaiheisiin\n\n• Suunnitelmien arviointi ja kustannusarvioiden laadinta\n\n• Viranomaisasioiden hoitamisen neuvonta\n\n• Ratkaisut asiakkaan tarpeen mukaan\n\n• Päätöksenteon helpottaminen ja projektin selkeyttäminen',
     link: '/konsultointipalvelut',
     logo: '/konsultointipalvelut-logo.svg'
@@ -32,6 +32,18 @@ const services = [
 function App() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    const scrollTarget = (location.state as { scrollTo?: string } | null)?.scrollTo;
+    if (scrollTarget === 'services') {
+      const element = document.getElementById('services');
+      if (element) {
+        element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+      navigate('.', { replace: true });
+    }
+  }, [location, navigate]);
 
   const handleServiceNavigation = (link?: string) => {
     if (!link) {

--- a/src/ArkkitehtisuunnitteluPage.tsx
+++ b/src/ArkkitehtisuunnitteluPage.tsx
@@ -1,4 +1,5 @@
 import { ArrowLeft } from 'lucide-react';
+import { Link } from 'react-router-dom';
 
 function ArkkitehtisuunnitteluPage() {
   return (
@@ -17,13 +18,14 @@ function ArkkitehtisuunnitteluPage() {
                 Aurinkokuninkaan Suunnittelu- ja Rakennuspalvelu Oy
               </span>
             </div>
-            <a
-              href="/"
+            <Link
+              to="/"
+              state={{ scrollTo: 'services' }}
               className="inline-flex items-center justify-center gap-2 rounded-lg border border-[#C9972E]/40 px-4 py-2.5 text-sm font-medium text-[#3E3326] transition-colors hover:bg-[#C9972E]/15 sm:text-base"
             >
               <ArrowLeft className="w-5 h-5" />
               Takaisin
-            </a>
+            </Link>
           </div>
         </nav>
       </header>

--- a/src/KonsultointipalvelutPage.tsx
+++ b/src/KonsultointipalvelutPage.tsx
@@ -1,4 +1,5 @@
 import { ArrowLeft } from 'lucide-react';
+import { Link } from 'react-router-dom';
 
 function KonsultointipalvelutPage() {
   return (
@@ -17,13 +18,14 @@ function KonsultointipalvelutPage() {
                 Aurinkokuninkaan Suunnittelu- ja Rakennuspalvelu Oy
               </span>
             </div>
-            <a
-              href="/"
+            <Link
+              to="/"
+              state={{ scrollTo: 'services' }}
               className="inline-flex items-center justify-center gap-2 rounded-lg border border-[#C9972E]/40 px-4 py-2.5 text-sm font-medium text-[#3E3326] transition-colors hover:bg-[#C9972E]/15 sm:text-base"
             >
               <ArrowLeft className="w-5 h-5" />
               Takaisin
-            </a>
+            </Link>
           </div>
         </nav>
       </header>

--- a/src/RakennesuunnitteluPage.tsx
+++ b/src/RakennesuunnitteluPage.tsx
@@ -1,4 +1,5 @@
 import { ArrowLeft } from 'lucide-react';
+import { Link } from 'react-router-dom';
 
 function RakennesuunnitteluPage() {
   return (
@@ -17,13 +18,14 @@ function RakennesuunnitteluPage() {
                 Aurinkokuninkaan Suunnittelu- ja Rakennuspalvelu Oy
               </span>
             </div>
-            <a
-              href="/"
+            <Link
+              to="/"
+              state={{ scrollTo: 'services' }}
               className="inline-flex items-center justify-center gap-2 rounded-lg border border-[#C9972E]/40 px-4 py-2.5 text-sm font-medium text-[#3E3326] transition-colors hover:bg-[#C9972E]/15 sm:text-base"
             >
               <ArrowLeft className="w-5 h-5" />
               Takaisin
-            </a>
+            </Link>
           </div>
         </nav>
       </header>

--- a/src/RakennuttajapalvelutPage.tsx
+++ b/src/RakennuttajapalvelutPage.tsx
@@ -1,4 +1,5 @@
 import { ArrowLeft } from 'lucide-react';
+import { Link } from 'react-router-dom';
 
 function RakennuttajapalvelutPage() {
   return (
@@ -17,13 +18,14 @@ function RakennuttajapalvelutPage() {
                 Aurinkokuninkaan Suunnittelu- ja Rakennuspalvelu Oy
               </span>
             </div>
-            <a
-              href="/"
+            <Link
+              to="/"
+              state={{ scrollTo: 'services' }}
               className="inline-flex items-center justify-center gap-2 rounded-lg border border-[#C9972E]/40 px-4 py-2.5 text-sm font-medium text-[#3E3326] transition-colors hover:bg-[#C9972E]/15 sm:text-base"
             >
               <ArrowLeft className="w-5 h-5" />
               Takaisin
-            </a>
+            </Link>
           </div>
         </nav>
       </header>


### PR DESCRIPTION
## Summary
- remove the extra "– pähkinänkuoressa" suffix from the Konsultointipalvelut service card title
- send users back to the Palvelut section when leaving a service page via the Takaisin button

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f0fce53c20832193afdf67e1b32049