### PR TITLE
Add branded footer bar with contact info and social icons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { type ChangeEvent, type FormEvent, type MouseEvent, useEffect, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { CalendarCheck, ClipboardList, Mail, Menu, Phone, User, X } from 'lucide-react';
+import Footer from './components/Footer';
 
 const services = [
   {
@@ -201,7 +202,7 @@ function App() {
               isMenuOpen ? 'max-h-96 opacity-100 mt-4' : 'pointer-events-none max-h-0 opacity-0'
             }`}
           >
-            <div className="flex flex-col gap-2 rounded-2xl border p-4 shadow-lg" style={{ backgroundColor: '#FEF8EB', borderColor: '#E0D2BF' }}>
+            <div className="flex flex-col gap-2 rounded-2xl border p-4 shadow-lg" style={{ backgroundColor: '#FEF8EB', borderColor: '#C9972E' }}>
               <a
                 href="#services"
                 onClick={(event) => handleAnchorClick(event, 'services')}
@@ -340,7 +341,7 @@ function App() {
           <div className="grid gap-10 lg:gap-12 lg:grid-cols-[minmax(0,320px)_1fr] items-start">
             <div
               className="rounded-3xl border shadow-lg p-8 flex flex-col items-center text-center"
-              style={{ backgroundColor: '#FEF8EB', borderColor: '#E0D2BF', color: '#3E3326' }}
+              style={{ backgroundColor: '#FEF8EB', borderColor: '#C9972E', color: '#3E3326' }}
             >
               <div className="w-32 h-32 sm:w-36 sm:h-36 rounded-full overflow-hidden mb-6 border-4" style={{ borderColor: '#C9972E' }}>
                 <img
@@ -359,7 +360,7 @@ function App() {
               </div>
             </div>
             <div className="space-y-6 text-base sm:text-lg leading-relaxed">
-              <div className="rounded-3xl border p-6 sm:p-8 shadow-sm" style={{ backgroundColor: '#FEF8EB', borderColor: '#E0D2BF' }}>
+              <div className="rounded-3xl border p-6 sm:p-8 shadow-sm" style={{ backgroundColor: '#FEF8EB', borderColor: '#C9972E' }}>
                 <p style={{ color: '#3E3326' }}>
                   Taustani ulottuu käytännön rakennustöistä työnjohtoon ja projektinhallintaan, joten ymmärrän rakentamista
                   monesta näkökulmasta. Työskentelyssäni yhdistyvät asiantuntemus, käytännön kokemus ja halu tehdä rakennusprojekteista
@@ -385,10 +386,13 @@ function App() {
         <div className="container mx-auto max-w-5xl">
           <div
             className="rounded-[32px] border shadow-2xl overflow-hidden"
-            style={{ backgroundColor: '#FEF8EB', borderColor: '#E0D2BF' }}
+            style={{ backgroundColor: '#FEF8EB', borderColor: '#C9972E' }}
           >
             <div className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(0,420px)] items-start">
-              <div className="px-6 py-8 sm:px-10 sm:py-12" style={{ backgroundColor: '#C9972E' }}>
+              <div
+                className="px-6 py-8 sm:px-10 sm:py-12 border"
+                style={{ backgroundColor: '#C9972E', borderColor: '#000000' }}
+              >
                 <div className="max-w-xl space-y-6 text-left">
                   <span
                     className="inline-flex items-center gap-2 rounded-full bg-white/15 px-4 py-1 text-sm font-semibold uppercase tracking-[0.25em]"
@@ -455,7 +459,7 @@ function App() {
                       className="w-full px-4 py-3 rounded-xl border-2 focus:outline-none focus:ring-4 focus:ring-[#C9972E]/20 focus:border-[#C9972E] transition-all"
                       style={{
                         backgroundColor: '#FEF8EB',
-                        borderColor: '#E0D2BF',
+                        borderColor: '#C9972E',
                         color: '#3E3326'
                       }}
                     />
@@ -476,7 +480,7 @@ function App() {
                       className="w-full px-4 py-3 rounded-xl border-2 focus:outline-none focus:ring-4 focus:ring-[#C9972E]/20 focus:border-[#C9972E] transition-all"
                       style={{
                         backgroundColor: '#FEF8EB',
-                        borderColor: '#E0D2BF',
+                        borderColor: '#C9972E',
                         color: '#3E3326'
                       }}
                     />
@@ -498,7 +502,7 @@ function App() {
                       className="w-full px-4 py-3 rounded-xl border-2 focus:outline-none focus:ring-4 focus:ring-[#C9972E]/20 focus:border-[#C9972E] transition-all"
                       style={{
                         backgroundColor: '#FEF8EB',
-                        borderColor: '#E0D2BF',
+                        borderColor: '#C9972E',
                         color: '#3E3326'
                       }}
                     />
@@ -515,7 +519,7 @@ function App() {
                       className="w-full px-4 py-3 rounded-xl border-2 focus:outline-none focus:ring-4 focus:ring-[#C9972E]/20 focus:border-[#C9972E] transition-all"
                       style={{
                         backgroundColor: '#FEF8EB',
-                        borderColor: '#E0D2BF',
+                        borderColor: '#C9972E',
                         color: '#3E3326'
                       }}
                     >
@@ -543,7 +547,7 @@ function App() {
                     className="w-full px-4 py-3 rounded-xl border-2 focus:outline-none focus:ring-4 focus:ring-[#C9972E]/20 focus:border-[#C9972E] transition-all"
                     style={{
                       backgroundColor: '#FEF8EB',
-                      borderColor: '#E0D2BF',
+                      borderColor: '#C9972E',
                       color: '#3E3326',
                       resize: 'vertical'
                     }}
@@ -581,14 +585,7 @@ function App() {
         </div>
       </section>
 
-      {/* Footer */}
-      <footer className="py-8 px-6" style={{ backgroundColor: 'rgba(201, 151, 46, 0.1)' }}>
-        <div className="container mx-auto text-center">
-          <p style={{ color: '#3E3326' }}>
-            &copy; 2025 Aurinkokuninkan Suunnittelu-ja Rakennuspalvelu OY. All rights reserved.
-          </p>
-        </div>
-      </footer>
+      <Footer />
     </div>
   );
 }

--- a/src/ProjektitPage.tsx
+++ b/src/ProjektitPage.tsx
@@ -1,5 +1,6 @@
 import { ArrowLeft, Calendar, MapPin, Ruler } from 'lucide-react';
 import { Link } from 'react-router-dom';
+import Footer from './components/Footer';
 
 function ProjektitPage() {
   const projects = [
@@ -182,14 +183,7 @@ function ProjektitPage() {
         </div>
       </section>
 
-      {/* Footer */}
-      <footer className="py-8 px-6" style={{ backgroundColor: 'rgba(201, 151, 46, 0.2)' }}>
-        <div className="container mx-auto text-center">
-          <p style={{ color: '#3E3326' }}>
-            &copy; 2025 Aurinkokuninkan Suunnittelu-ja Rakennuspalvelu OY. All rights reserved.
-          </p>
-        </div>
-      </footer>
+      <Footer />
     </div>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,66 @@
+import { Facebook, Instagram } from 'lucide-react';
+import type { SVGProps } from 'react';
+
+const TikTokIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path
+      fill="currentColor"
+      d="M21 8.5c-1.8 0-3.4-.6-4.7-1.6v7.3c0 3.5-2.8 6.3-6.3 6.3S3.7 17.7 3.7 14.2c0-3.2 2.3-5.8 5.3-6.2v3.4c-1.1.3-2 1.3-2 2.6 0 1.5 1.2 2.7 2.7 2.7s2.7-1.2 2.7-2.7V3h3.6c.2 1.9 1.7 3.4 3.6 3.6V8.5z"
+    />
+  </svg>
+);
+
+const iconStyle = { color: '#3E3326' } as const;
+
+const socialLinks = [
+  {
+    label: 'Instagram',
+    Icon: Instagram,
+    href: '#'
+  },
+  {
+    label: 'Facebook',
+    Icon: Facebook,
+    href: '#'
+  },
+  {
+    label: 'TikTok',
+    Icon: TikTokIcon,
+    href: '#'
+  }
+];
+
+function Footer() {
+  return (
+    <footer className="px-6 py-6" style={{ backgroundColor: '#C9972E' }}>
+      <div className="container mx-auto flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-1 text-center sm:text-left">
+          <p className="text-sm sm:text-base font-medium" style={{ color: '#3E3326' }}>
+            &copy; 2025 Aurinkokuninkan Suunnittelu-ja Rakennuspalvelu OY. All rights reserved.
+          </p>
+          <p className="text-sm sm:text-base" style={{ color: '#3E3326' }}>
+            Purolantie 9 35800 Mänttä
+          </p>
+          <p className="text-sm sm:text-base" style={{ color: '#3E3326' }}>
+            Y-tunnus 3569037-1
+          </p>
+        </div>
+        <div className="flex items-center justify-center gap-4">
+          {socialLinks.map(({ label, Icon, href }) => (
+            <a
+              key={label}
+              href={href}
+              aria-label={label}
+              className="flex h-11 w-11 items-center justify-center rounded-full border-2 transition-transform hover:-translate-y-0.5"
+              style={{ borderColor: '#3E3326', color: '#3E3326' }}
+            >
+              <Icon className="h-5 w-5" style={iconStyle} />
+            </a>
+          ))}
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+export default Footer;


### PR DESCRIPTION
## Summary
- replace the previous page footers with a shared gold bottom bar component
- show the existing copyright notice along with the new street address and business ID
- surface Instagram, Facebook, and TikTok icon slots for future social links on the right edge

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f2858da2e48321a34a8f6969cef5b3