### PR TITLE
Update contact section copy and project CTA navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,8 +48,8 @@ function App() {
 
   useEffect(() => {
     const scrollTarget = (location.state as { scrollTo?: string } | null)?.scrollTo;
-    if (scrollTarget === 'services') {
-      const element = document.getElementById('services');
+    if (scrollTarget) {
+      const element = document.getElementById(scrollTarget);
       if (element) {
         element.scrollIntoView({ behavior: 'smooth', block: 'start' });
       }
@@ -419,7 +419,7 @@ function App() {
                       <CalendarCheck className="mt-1 h-5 w-5" />
                       <div>
                         <p className="font-semibold text-white">Toiminta-alue</p>
-                        <p>Suunnittelu- ja rakennusprojektit koko Uudellamaalla ja sopimuksesta muualla Suomessa</p>
+                        <p>Pirkanmaa ja koko Suomi sopimuksen mukaan</p>
                       </div>
                     </div>
                   </div>

--- a/src/ProjektitPage.tsx
+++ b/src/ProjektitPage.tsx
@@ -176,7 +176,8 @@ function ProjektitPage() {
             Haluatko toteuttaa oman rakennusprojektisi? Ota yhteyttä ja keskustellaan, miten voimme auttaa visiosi toteutumisessa.
           </p>
           <Link
-            to="/#contact"
+            to="/"
+            state={{ scrollTo: 'contact' }}
             className="inline-block rounded-lg px-6 py-3 text-sm font-semibold text-white transition-opacity hover:opacity-90 sm:px-8 sm:py-4 sm:text-lg"
             style={{ backgroundColor: '#C9972E' }}
           >


### PR DESCRIPTION
## Summary
- update the contact section location text to reflect the new service area wording
- allow the home page to scroll to any section based on router state
- point the projects page contact button to the home page form using the new scroll state

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f28e27dadc832185c8456bfcd8430b