### PR TITLE
Improve logo contrast and sizing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { type ChangeEvent, type FormEvent, type MouseEvent, useEffect, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { CalendarCheck, ClipboardList, Mail, Menu, Phone, User, X } from 'lucide-react';
+import aurinkokuningasLogo from '../assets/aurinkokuningas.png';
 import Footer from './components/Footer';
 
 const services = [
@@ -144,9 +145,9 @@ function App() {
           <div className="flex items-center justify-between gap-4">
             <div className="flex flex-1 items-center gap-4">
               <img
-                src="/logo.svg"
-                alt="Aurinkokuninkan Logo"
-                className="h-14 w-14 object-contain flex-shrink-0"
+                src={aurinkokuningasLogo}
+                alt="Aurinkokuninkaan Logo"
+                className="h-16 w-auto object-contain flex-shrink-0 mix-blend-multiply md:h-20"
               />
               <span className="text-sm sm:text-base md:text-lg font-semibold leading-snug" style={{ color: '#3E3326' }}>
                 Aurinkokuninkaan Suunnittelu- ja Rakennuspalvelu Oy

--- a/src/ArkkitehtisuunnitteluPage.tsx
+++ b/src/ArkkitehtisuunnitteluPage.tsx
@@ -1,5 +1,6 @@
 import { ArrowLeft } from 'lucide-react';
 import { Link } from 'react-router-dom';
+import aurinkokuningasLogo from '../assets/aurinkokuningas.png';
 
 function ArkkitehtisuunnitteluPage() {
   return (
@@ -13,9 +14,9 @@ function ArkkitehtisuunnitteluPage() {
           <div className="flex flex-col gap-4 text-center sm:flex-row sm:items-center sm:justify-between sm:text-left">
             <div className="flex items-center justify-center gap-4 sm:justify-start">
               <img
-                src="/logo.svg"
-                alt="Aurinkokuninkan Logo"
-                className="h-12 w-12 sm:h-14 sm:w-14 object-contain"
+                src={aurinkokuningasLogo}
+                alt="Aurinkokuninkaan Logo"
+                className="h-14 w-auto object-contain mix-blend-multiply sm:h-16 md:h-20"
               />
               <span className="text-base font-semibold sm:text-lg" style={{ color: '#3E3326' }}>
                 Aurinkokuninkaan Suunnittelu- ja Rakennuspalvelu Oy

--- a/src/KonsultointipalvelutPage.tsx
+++ b/src/KonsultointipalvelutPage.tsx
@@ -1,5 +1,6 @@
 import { ArrowLeft } from 'lucide-react';
 import { Link } from 'react-router-dom';
+import aurinkokuningasLogo from '../assets/aurinkokuningas.png';
 
 function KonsultointipalvelutPage() {
   return (
@@ -13,9 +14,9 @@ function KonsultointipalvelutPage() {
           <div className="flex flex-col gap-4 text-center sm:flex-row sm:items-center sm:justify-between sm:text-left">
             <div className="flex items-center justify-center gap-4 sm:justify-start">
               <img
-                src="/logo.svg"
-                alt="Aurinkokuninkan Logo"
-                className="h-12 w-12 sm:h-14 sm:w-14 object-contain"
+                src={aurinkokuningasLogo}
+                alt="Aurinkokuninkaan Logo"
+                className="h-14 w-auto object-contain mix-blend-multiply sm:h-16 md:h-20"
               />
               <span className="text-base font-semibold sm:text-lg" style={{ color: '#3E3326' }}>
                 Aurinkokuninkaan Suunnittelu- ja Rakennuspalvelu Oy

--- a/src/ProjektitPage.tsx
+++ b/src/ProjektitPage.tsx
@@ -1,5 +1,6 @@
 import { ArrowLeft, Calendar, MapPin, Ruler } from 'lucide-react';
 import { Link } from 'react-router-dom';
+import aurinkokuningasLogo from '../assets/aurinkokuningas.png';
 import Footer from './components/Footer';
 
 function ProjektitPage() {
@@ -64,9 +65,9 @@ function ProjektitPage() {
           <div className="flex flex-col gap-4 text-center sm:flex-row sm:items-center sm:justify-between sm:text-left">
             <Link to="/" className="flex items-center justify-center gap-4 transition-opacity hover:opacity-80 sm:justify-start">
               <img
-                src="/logo.svg"
-                alt="Aurinkokuninkan Logo"
-                className="h-12 w-12 sm:h-14 sm:w-14 object-contain"
+                src={aurinkokuningasLogo}
+                alt="Aurinkokuninkaan Logo"
+                className="h-14 w-auto object-contain mix-blend-multiply sm:h-16 md:h-20"
               />
               <span className="text-base font-semibold sm:text-lg" style={{ color: '#3E3326' }}>
                 Aurinkokuninkaan Suunnittelu- ja Rakennuspalvelu Oy

--- a/src/RakennesuunnitteluPage.tsx
+++ b/src/RakennesuunnitteluPage.tsx
@@ -1,5 +1,6 @@
 import { ArrowLeft } from 'lucide-react';
 import { Link } from 'react-router-dom';
+import aurinkokuningasLogo from '../assets/aurinkokuningas.png';
 
 function RakennesuunnitteluPage() {
   return (
@@ -13,9 +14,9 @@ function RakennesuunnitteluPage() {
           <div className="flex flex-col gap-4 text-center sm:flex-row sm:items-center sm:justify-between sm:text-left">
             <div className="flex items-center justify-center gap-4 sm:justify-start">
               <img
-                src="/logo.svg"
-                alt="Aurinkokuninkan Logo"
-                className="h-12 w-12 sm:h-14 sm:w-14 object-contain"
+                src={aurinkokuningasLogo}
+                alt="Aurinkokuninkaan Logo"
+                className="h-14 w-auto object-contain mix-blend-multiply sm:h-16 md:h-20"
               />
               <span className="text-base font-semibold sm:text-lg" style={{ color: '#3E3326' }}>
                 Aurinkokuninkaan Suunnittelu- ja Rakennuspalvelu Oy

--- a/src/RakennuttajapalvelutPage.tsx
+++ b/src/RakennuttajapalvelutPage.tsx
@@ -1,5 +1,6 @@
 import { ArrowLeft } from 'lucide-react';
 import { Link } from 'react-router-dom';
+import aurinkokuningasLogo from '../assets/aurinkokuningas.png';
 
 function RakennuttajapalvelutPage() {
   return (
@@ -13,9 +14,9 @@ function RakennuttajapalvelutPage() {
           <div className="flex flex-col gap-4 text-center sm:flex-row sm:items-center sm:justify-between sm:text-left">
             <div className="flex items-center justify-center gap-4 sm:justify-start">
               <img
-                src="/logo.svg"
-                alt="Aurinkokuninkan Logo"
-                className="h-12 w-12 sm:h-14 sm:w-14 object-contain"
+                src={aurinkokuningasLogo}
+                alt="Aurinkokuninkaan Logo"
+                className="h-14 w-auto object-contain mix-blend-multiply sm:h-16 md:h-20"
               />
               <span className="text-base font-semibold sm:text-lg" style={{ color: '#3E3326' }}>
                 Aurinkokuninkaan Suunnittelu- ja Rakennuspalvelu Oy

--- a/src/YhteystiedotPage.tsx
+++ b/src/YhteystiedotPage.tsx
@@ -1,4 +1,5 @@
 import { ArrowLeft, Mail, MapPin, Phone, MessageCircle } from 'lucide-react';
+import aurinkokuningasLogo from '../assets/aurinkokuningas.png';
 
 function YhteystiedotPage() {
   return (
@@ -11,7 +12,11 @@ function YhteystiedotPage() {
         <nav className="px-4 sm:px-6 py-4">
           <div className="flex flex-col gap-4 text-center sm:flex-row sm:items-center sm:justify-between sm:text-left">
             <div className="flex items-center justify-center gap-4 sm:justify-start">
-              <img src="/logo.svg" alt="Aurinkokuninkaan Logo" className="h-12 w-12 sm:h-14 sm:w-14 object-contain" />
+              <img
+                src={aurinkokuningasLogo}
+                alt="Aurinkokuninkaan Logo"
+                className="h-14 w-auto object-contain mix-blend-multiply sm:h-16 md:h-20"
+              />
               <span className="text-base font-semibold sm:text-lg" style={{ color: '#3E3326' }}>
                 Aurinkokuninkaan Suunnittelu- ja Rakennuspalvelu Oy
               </span>


### PR DESCRIPTION
## Summary
- enlarge the header logo across all pages for better visibility
- apply a multiply blend mode so the logo background blends with the site theme instead of showing white fill

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f6895ab3e8832189a2ca4fe8fc881f