### PR TITLE
Remove click functionality from contact details

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -358,20 +358,12 @@ function App() {
                 <h3 className="text-xl sm:text-2xl font-semibold">Tami Takala</h3>
                 <div className="space-y-1 text-sm sm:text-base" style={{ color: '#3E3326', opacity: 0.85 }}>
                   <p className="font-medium" style={{ opacity: 0.9 }}>Yrittäjä</p>
-                  <a
-                    href="tel:+358401547538"
-                    className="block transition-colors hover:text-[#C9972E] focus:text-[#C9972E] focus:outline-none"
-                    style={{ color: '#3E3326' }}
-                  >
+                  <p className="block font-medium" style={{ color: '#3E3326' }}>
                     +358 40 154 7538
-                  </a>
-                  <a
-                    href="mailto:tami.takala@aurinkokuningasoy.fi"
-                    className="block transition-colors hover:text-[#C9972E] focus:text-[#C9972E] focus:outline-none"
-                    style={{ color: '#3E3326' }}
-                  >
+                  </p>
+                  <p className="block font-medium" style={{ color: '#3E3326' }}>
                     tami.takala@aurinkokuningasoy.fi
-                  </a>
+                  </p>
                 </div>
               </div>
             </div>
@@ -428,12 +420,9 @@ function App() {
                       <Phone className="mt-1 h-5 w-5" />
                       <div>
                         <p className="font-semibold text-white">Suora puhelin</p>
-                        <a
-                          href="tel:+358401547538"
-                          className="text-white transition-opacity hover:opacity-80 focus:opacity-80 focus:outline-none"
-                        >
+                        <p className="text-white font-medium">
                           +358 40 154 7538
-                        </a>
+                        </p>
                       </div>
                     </div>
                     <div className="flex items-start gap-3">

--- a/src/YhteystiedotPage.tsx
+++ b/src/YhteystiedotPage.tsx
@@ -77,7 +77,7 @@ function YhteystiedotPage() {
                     title: 'Puhelin',
                     value: '+358 40 154 7538',
                     helper: 'Parhaiten tavoitat arkisin klo 8–17',
-                    href: 'tel:+358401547538'
+                    emphasize: true
                   },
                   {
                     icon: <MapPin className="w-6 h-6" />,
@@ -91,7 +91,7 @@ function YhteystiedotPage() {
                     value: 'tami.takala@aurinkokuningasoy.fi',
                     helper: 'Vastaamme viesteihin yhden arkipäivän sisällä',
                     wrapperClassName: 'md:col-span-2',
-                    href: 'mailto:tami.takala@aurinkokuningasoy.fi'
+                    emphasize: true
                   }
                 ].map((item, index) => (
                   <div
@@ -110,22 +110,14 @@ function YhteystiedotPage() {
                     <h3 className="text-base sm:text-lg font-semibold mb-2" style={{ color: '#3E3326' }}>
                       {item.title}
                     </h3>
-                    {item.href ? (
-                      <a
-                        href={item.href}
-                        className="text-sm sm:text-base leading-relaxed break-words font-medium transition-colors hover:text-[#C9972E] focus:text-[#C9972E] focus:outline-none"
-                        style={{ color: '#3E3326' }}
-                      >
-                        {item.value}
-                      </a>
-                    ) : (
-                      <p
-                        className="text-sm sm:text-base leading-relaxed break-words"
-                        style={{ color: '#3E3326' }}
-                      >
-                        {item.value}
-                      </p>
-                    )}
+                    <p
+                      className={`text-sm sm:text-base leading-relaxed break-words ${
+                        item.emphasize ? 'font-medium' : ''
+                      }`}
+                      style={{ color: '#3E3326' }}
+                    >
+                      {item.value}
+                    </p>
                     {item.helper && (
                       <p className="mt-3 text-xs sm:text-sm" style={{ color: '#3E3326', opacity: 0.75 }}>
                         {item.helper}


### PR DESCRIPTION
## Summary
- render phone and email details as plain text on the about and contact sections
- update the contact details page to remove tel/mailto links while preserving styling emphasis

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f8a39a45588321902dbddfba3c4d54