### PR TITLE
Add Aurinkokuningas logo to homepage header

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,14 @@
     <title>New chat</title>
   </head>
   <body>
+    <header class="flex justify-center py-8">
+      <img
+        src="/logos/logo.svg"
+        alt="Aurinkokuningas Oy logo"
+        class="h-16 w-auto object-contain md:h-20"
+        loading="lazy"
+      />
+    </header>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/public/logos/logo.svg
+++ b/public/logos/logo.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" role="img" aria-labelledby="title desc">
+  <title id="title">Aurinkokuningas Oy emblem</title>
+  <desc id="desc">Stylised sun emblem for Aurinkokuningas Oy without text.</desc>
+  <defs>
+    <radialGradient id="sunCore" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#fff3b0" />
+      <stop offset="55%" stop-color="#ffd166" />
+      <stop offset="100%" stop-color="#f77f00" />
+    </radialGradient>
+    <linearGradient id="sunRays" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#fcbf49" />
+      <stop offset="100%" stop-color="#f77f00" />
+    </linearGradient>
+  </defs>
+  <g transform="translate(100 100)">
+    <circle
+      r="78"
+      fill="none"
+      stroke="url(#sunRays)"
+      stroke-width="20"
+      stroke-dasharray="12 20"
+      stroke-linecap="round"
+      transform="rotate(-15)"
+    />
+    <circle r="50" fill="url(#sunCore)" />
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- add the Aurinkokuningas Oy logo asset under public/logos
- display the logo in a centered header on the homepage with responsive sizing

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68f8a344d0b88321bb16bf860d53700c