### PR TITLE
Position service logos in Palvelut cards

### DIFF
--- a/public/logos/arkkitehtisuunnittelu.svg
+++ b/public/logos/arkkitehtisuunnittelu.svg
@@ -1,0 +1,13 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="24" y="32" width="112" height="96" rx="16" stroke="#C9972E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M48 96L80 68L112 96" stroke="#C9972E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M64 96V128" stroke="#C9972E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M96 96V128" stroke="#C9972E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M80 68V48" stroke="#C9972E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M40 64H64" stroke="#C9972E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M96 64H120" stroke="#C9972E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M40 80H56" stroke="#C9972E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M104 80H120" stroke="#C9972E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M56 44V56" stroke="#C9972E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M104 44V56" stroke="#C9972E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/public/logos/konsultointi.svg
+++ b/public/logos/konsultointi.svg
@@ -1,0 +1,8 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M116 32H60C47.8497 32 38 41.8497 38 54V84C38 96.1503 47.8497 106 60 106H68V126L92 106H116C128.15 106 138 96.1503 138 84V54C138 41.8497 128.15 32 116 32Z" stroke="#C9972E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M22 76V98C22 110.15 31.8497 120 44 120H52V140L74 120" stroke="#C9972E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="80" cy="66" r="6" fill="#C9972E" />
+  <circle cx="104" cy="66" r="6" fill="#C9972E" />
+  <circle cx="56" cy="88" r="6" fill="#C9972E" />
+  <circle cx="80" cy="88" r="6" fill="#C9972E" />
+</svg>

--- a/public/logos/rakennesuunnittelu.svg
+++ b/public/logos/rakennesuunnittelu.svg
@@ -1,0 +1,9 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="28" y="32" width="104" height="96" rx="12" stroke="#C9972E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M52 116V44" stroke="#C9972E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M108 116V44" stroke="#C9972E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M52 68H108" stroke="#C9972E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M52 92H108" stroke="#C9972E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M52 44L80 68L108 44" stroke="#C9972E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M52 116L80 92L108 116" stroke="#C9972E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/public/logos/rakennuttajapalvelu.svg
+++ b/public/logos/rakennuttajapalvelu.svg
@@ -1,0 +1,7 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M32 86L60 58C66.6274 51.3726 77.3726 51.3726 84 58L106 80C112.627 86.6274 112.627 97.3726 106 104L94 116C87.3726 122.627 76.6274 122.627 70 116L32 78" stroke="#C9972E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M128 74L102 100" stroke="#C9972E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M110 46L136 72C142.627 78.6274 142.627 89.3726 136 96L112 120C105.373 126.627 94.6274 126.627 88 120L70 102" stroke="#C9972E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M52 106L66 120" stroke="#C9972E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M64 94L78 108" stroke="#C9972E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,22 +9,25 @@ const services = [
     title: 'Arkkitehtisuunnittelu',
     desc: '• Asemapiirustus\n\n• Pohjapiirustus\n\n• Leikkauspiirustukset\n\n• Julkisivukuvat',
     link: '/arkkitehtisuunnittelu',
-    logo: '/arkkitehtisuunnittelu-service-logo.svg'
+    logo: { src: '/logos/arkkitehtisuunnittelu.svg', alt: 'Arkkitehtisuunnittelu' }
   },
   {
     title: 'Rakennesuunnittelu',
     desc: '• Turvalliset ja kestävät rakenteet kaikkiin kohteisiin\n\n• Ratkaisut, jotka tukevat arkkitehtisuunnittelua ja helpottavat työmaan toteutusta\n\n• Selkeät ja luotettavat rakennesuunnitelmat, jotka tekevät rakentamisesta sujuvampaa',
-    link: '/rakennesuunnittelu'
+    link: '/rakennesuunnittelu',
+    logo: { src: '/logos/rakennesuunnittelu.svg', alt: 'Rakennesuunnittelu' }
   },
   {
     title: 'Konsultointipalvelut',
     desc: '• Asiantuntevaa tukea rakennushankkeen eri vaiheisiin\n\n• Suunnitelmien arviointi ja kustannusarvioiden laadinta\n\n• Viranomaisasioiden hoitamisen neuvonta\n\n• Ratkaisut asiakkaan tarpeen mukaan\n\n• Päätöksenteon helpottaminen ja projektin selkeyttäminen',
-    link: '/konsultointipalvelut'
+    link: '/konsultointipalvelut',
+    logo: { src: '/logos/konsultointi.svg', alt: 'Konsultointi' }
   },
   {
     title: 'Rakennuttajapalvelut',
     desc: '• Vastaavatyönjohtaja\n\n• Pääsuunnittelija\n\n• Rakennushankkeen hallinta alusta loppuun\n\n• Asiakkaan edunvalvonta koko projektin ajan\n\n• Vaivattomampi ja hallitumpi rakennusprosessi',
-    link: '/rakennuttajapalvelut'
+    link: '/rakennuttajapalvelut',
+    logo: { src: '/logos/rakennuttajapalvelu.svg', alt: 'Rakennuttajapalvelu' }
   }
 ];
 
@@ -264,17 +267,6 @@ function App() {
           </h2>
           <div className="grid gap-6 sm:gap-8 md:grid-cols-2 max-w-6xl mx-auto">
             {services.map((service, index) => {
-              const isArkkitehtisuunnittelu = service.title === 'Arkkitehtisuunnittelu';
-              const logoElement =
-                isArkkitehtisuunnittelu && service.logo ? (
-                  <img
-                    src={service.logo}
-                    alt="Arkkitehtisuunnittelu logo"
-                    className="absolute top-4 right-4 w-16 h-16 sm:w-20 sm:h-20 opacity-90 select-none pointer-events-none"
-                    aria-hidden={true}
-                  />
-                ) : null;
-
               const ServiceBox = (
                 <div
                   key={index}
@@ -295,8 +287,15 @@ function App() {
                     }
                   }}
                 >
-                  {logoElement}
-                  <div className="relative z-10 flex h-full flex-col gap-6 p-6 sm:p-8 lg:p-10">
+                  {service.logo && (
+                    <img
+                      src={service.logo.src}
+                      alt={service.logo.alt}
+                      className="absolute right-6 top-6 h-12 w-auto object-contain sm:h-14 md:h-16"
+                      loading="lazy"
+                    />
+                  )}
+                  <div className="relative z-10 flex h-full flex-col gap-6 p-6 pr-24 sm:p-8 sm:pr-32 lg:p-10 lg:pr-40">
                     <h3
                       className="text-xl sm:text-2xl font-bold"
                       style={{ color: '#3E3326', lineHeight: '1.4', letterSpacing: '0.01em' }}


### PR DESCRIPTION
## Summary
- add logo metadata to each Palvelut service entry for direct use in the UI
- position each service logo in the top-right corner of its card with additional padding to preserve layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f8ad5f485c83219d4ce27e13e9b765