### PR TITLE
Replace arkkitehtisuunnittelu logo with masked component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,33 +1,68 @@
-import { type ChangeEvent, type FormEvent, type MouseEvent, useEffect, useState } from 'react';
+import { type ChangeEvent, type FormEvent, type MouseEvent, type ReactNode, useEffect, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { CalendarCheck, ClipboardList, Mail, Megaphone, Menu, Phone, User, X } from 'lucide-react';
+import BrandLogo from '@/components/BrandLogo';
 import aurinkokuningasLogo from '../assets/aurinkokuningas.png';
 import Footer from './components/Footer';
 
-const services = [
+type Service = {
+  title: string;
+  desc: string;
+  link?: string;
+  logo?: ReactNode;
+};
+
+const services: Service[] = [
   {
     title: 'Arkkitehtisuunnittelu',
     desc: '• Asemapiirustus\n\n• Pohjapiirustus\n\n• Leikkauspiirustukset\n\n• Julkisivukuvat',
     link: '/arkkitehtisuunnittelu',
-    logo: { src: '/logos/arkkitehtisuunnittelu.svg', alt: 'Arkkitehtisuunnittelu' }
+    logo: (
+      <BrandLogo
+        size={56}
+        className="absolute right-6 top-6"
+        label="Arkkitehtisuunnittelun logo"
+      />
+    )
   },
   {
     title: 'Rakennesuunnittelu',
     desc: '• Turvalliset ja kestävät rakenteet kaikkiin kohteisiin\n\n• Ratkaisut, jotka tukevat arkkitehtisuunnittelua ja helpottavat työmaan toteutusta\n\n• Selkeät ja luotettavat rakennesuunnitelmat, jotka tekevät rakentamisesta sujuvampaa',
     link: '/rakennesuunnittelu',
-    logo: { src: '/logos/rakennesuunnittelu.svg', alt: 'Rakennesuunnittelu' }
+    logo: (
+      <img
+        src="/logos/rakennesuunnittelu.svg"
+        alt="Rakennesuunnittelu"
+        className="absolute right-6 top-6 h-12 w-auto object-contain sm:h-14 md:h-16"
+        loading="lazy"
+      />
+    )
   },
   {
     title: 'Konsultointipalvelut',
     desc: '• Asiantuntevaa tukea rakennushankkeen eri vaiheisiin\n\n• Suunnitelmien arviointi ja kustannusarvioiden laadinta\n\n• Viranomaisasioiden hoitamisen neuvonta\n\n• Ratkaisut asiakkaan tarpeen mukaan\n\n• Päätöksenteon helpottaminen ja projektin selkeyttäminen',
     link: '/konsultointipalvelut',
-    logo: { src: '/logos/konsultointi.svg', alt: 'Konsultointi' }
+    logo: (
+      <img
+        src="/logos/konsultointi.svg"
+        alt="Konsultointi"
+        className="absolute right-6 top-6 h-12 w-auto object-contain sm:h-14 md:h-16"
+        loading="lazy"
+      />
+    )
   },
   {
     title: 'Rakennuttajapalvelut',
     desc: '• Vastaavatyönjohtaja\n\n• Pääsuunnittelija\n\n• Rakennushankkeen hallinta alusta loppuun\n\n• Asiakkaan edunvalvonta koko projektin ajan\n\n• Vaivattomampi ja hallitumpi rakennusprosessi',
     link: '/rakennuttajapalvelut',
-    logo: { src: '/logos/rakennuttajapalvelu.svg', alt: 'Rakennuttajapalvelu' }
+    logo: (
+      <img
+        src="/logos/rakennuttajapalvelu.svg"
+        alt="Rakennuttajapalvelu"
+        className="absolute right-6 top-6 h-12 w-auto object-contain sm:h-14 md:h-16"
+        loading="lazy"
+      />
+    )
   }
 ];
 
@@ -287,14 +322,7 @@ function App() {
                     }
                   }}
                 >
-                  {service.logo && (
-                    <img
-                      src={service.logo.src}
-                      alt={service.logo.alt}
-                      className="absolute right-6 top-6 h-12 w-auto object-contain sm:h-14 md:h-16"
-                      loading="lazy"
-                    />
-                  )}
+                  {service.logo}
                   <div className="relative z-10 flex h-full flex-col gap-6 p-6 pr-24 sm:p-8 sm:pr-32 lg:p-10 lg:pr-40">
                     <h3
                       className="text-xl sm:text-2xl font-bold"

--- a/src/components/BrandLogo.tsx
+++ b/src/components/BrandLogo.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+
+type Props = {
+  /** Square size in px (default 48 ~ Tailwind h-12) */
+  size?: number;
+  /** Hex or CSS color for the logo (default brand gold) */
+  color?: string;
+  className?: string;
+  /** aria-label for accessibility */
+  label?: string;
+};
+
+export default function BrandLogo({
+  size = 48,
+  color = "#C9972E",
+  className = "",
+  label = "Company logo",
+}: Props) {
+  return (
+    <div
+      role="img"
+      aria-label={label}
+      className={className}
+      style={{
+        width: `${size}px`,
+        height: `${size}px`,
+        backgroundColor: color,
+        WebkitMaskImage: "url(/logos/arkkitehtisuunnittelu.svg)",
+        maskImage: "url(/logos/arkkitehtisuunnittelu.svg)",
+        WebkitMaskRepeat: "no-repeat",
+        maskRepeat: "no-repeat",
+        WebkitMaskPosition: "center",
+        maskPosition: "center",
+        WebkitMaskSize: "contain",
+        maskSize: "contain",
+        display: "inline-block",
+      }}
+    />
+  );
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -13,6 +13,10 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
 
     /* Linting */
     "strict": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,15 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { fileURLToPath, URL } from 'node:url';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
   optimizeDeps: {
     exclude: ['lucide-react'],
   },


### PR DESCRIPTION
## Summary
- add a reusable BrandLogo component that masks the arkkitehtisuunnittelu SVG with configurable color
- swap the services grid to use the new component and keep other logos unchanged
- configure the `@` import alias for the new component path

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f905c2b46c832186f68e758df303ba