### PR TITLE
Remove Palvelut section logo imagery

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEvent, type FormEvent, type MouseEvent, type ReactNode, useEffect, useState } from 'react';
+import { type ChangeEvent, type FormEvent, type MouseEvent, useEffect, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { CalendarCheck, ClipboardList, Mail, Megaphone, Menu, Phone, User, X } from 'lucide-react';
 import aurinkokuningasLogo from '../assets/aurinkokuningas.png';
@@ -8,61 +8,28 @@ type Service = {
   title: string;
   desc: string;
   link?: string;
-  logo?: ReactNode;
 };
 
 const services: Service[] = [
   {
     title: 'Arkkitehtisuunnittelu',
     desc: '• Asemapiirustus\n\n• Pohjapiirustus\n\n• Leikkauspiirustukset\n\n• Julkisivukuvat',
-    link: '/arkkitehtisuunnittelu',
-    logo: (
-      <img
-        src="/logos/arkkitehtisuunnittelu.svg"
-        alt="Arkkitehtisuunnittelu"
-        className="absolute right-6 top-6 h-16 w-auto object-contain sm:h-20"
-        loading="lazy"
-      />
-    )
+    link: '/arkkitehtisuunnittelu'
   },
   {
     title: 'Rakennesuunnittelu',
     desc: '• Turvalliset ja kestävät rakenteet kaikkiin kohteisiin\n\n• Ratkaisut, jotka tukevat arkkitehtisuunnittelua ja helpottavat työmaan toteutusta\n\n• Selkeät ja luotettavat rakennesuunnitelmat, jotka tekevät rakentamisesta sujuvampaa',
-    link: '/rakennesuunnittelu',
-    logo: (
-      <img
-        src="/logos/rakennesuunnittelu.svg"
-        alt="Rakennesuunnittelu"
-        className="absolute right-6 top-6 h-12 w-auto object-contain sm:h-14 md:h-16"
-        loading="lazy"
-      />
-    )
+    link: '/rakennesuunnittelu'
   },
   {
     title: 'Konsultointipalvelut',
     desc: '• Asiantuntevaa tukea rakennushankkeen eri vaiheisiin\n\n• Suunnitelmien arviointi ja kustannusarvioiden laadinta\n\n• Viranomaisasioiden hoitamisen neuvonta\n\n• Ratkaisut asiakkaan tarpeen mukaan\n\n• Päätöksenteon helpottaminen ja projektin selkeyttäminen',
-    link: '/konsultointipalvelut',
-    logo: (
-      <img
-        src="/logos/konsultointi.svg"
-        alt="Konsultointi"
-        className="absolute right-6 top-6 h-12 w-auto object-contain sm:h-14 md:h-16"
-        loading="lazy"
-      />
-    )
+    link: '/konsultointipalvelut'
   },
   {
     title: 'Rakennuttajapalvelut',
     desc: '• Vastaavatyönjohtaja\n\n• Pääsuunnittelija\n\n• Rakennushankkeen hallinta alusta loppuun\n\n• Asiakkaan edunvalvonta koko projektin ajan\n\n• Vaivattomampi ja hallitumpi rakennusprosessi',
-    link: '/rakennuttajapalvelut',
-    logo: (
-      <img
-        src="/logos/rakennuttajapalvelu.svg"
-        alt="Rakennuttajapalvelu"
-        className="absolute right-6 top-6 h-12 w-auto object-contain sm:h-14 md:h-16"
-        loading="lazy"
-      />
-    )
+    link: '/rakennuttajapalvelut'
   }
 ];
 
@@ -322,8 +289,7 @@ function App() {
                     }
                   }}
                 >
-                  {service.logo}
-                  <div className="relative z-10 flex h-full flex-col gap-6 p-6 pr-24 sm:p-8 sm:pr-32 lg:p-10 lg:pr-40">
+                  <div className="relative z-10 flex h-full flex-col gap-6 p-6 sm:p-8 lg:p-10">
                     <h3
                       className="text-xl sm:text-2xl font-bold"
                       style={{ color: '#3E3326', lineHeight: '1.4', letterSpacing: '0.01em' }}


### PR DESCRIPTION
## Summary
- remove the service card logo definitions so the Palvelut section no longer renders SVGs
- tidy the service card layout spacing after removing the logos

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fa59dde87483219ee8bc77f70edca0