### PR TITLE
Refresh Palvelut logo backgrounds

### DIFF
--- a/assets/palvelut/arkkitehtisuunnittelu-bg.svg
+++ b/assets/palvelut/arkkitehtisuunnittelu-bg.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 900" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="arkkitehtiPalette" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#20160E" />
+      <stop offset="100%" stop-color="#3B2C1B" />
+    </linearGradient>
+    <pattern id="arkkitehtiGrid" width="60" height="60" patternUnits="userSpaceOnUse">
+      <path d="M60 0H0v60" fill="none" stroke="#8D7452" stroke-opacity="0.12" stroke-width="2" />
+    </pattern>
+    <filter id="arkkitehtiShadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#000" flood-opacity="0.4" />
+    </filter>
+  </defs>
+  <rect width="1200" height="900" fill="url(#arkkitehtiPalette)" />
+  <rect width="1200" height="900" fill="url(#arkkitehtiGrid)" />
+  <g transform="translate(600 440)">
+    <circle r="220" fill="#2B1F13" stroke="#F4E7D1" stroke-width="8" filter="url(#arkkitehtiShadow)" />
+    <g transform="translate(-120 -120)" fill="none" stroke="#F4E7D1" stroke-linecap="round" stroke-linejoin="round">
+      <rect x="28" y="40" width="304" height="196" rx="26" stroke-width="14" />
+      <path d="M180 40v196" stroke-width="10" opacity="0.7" />
+      <path d="M180 80l74 52-74 52-74-52 74-52z" stroke-width="12" />
+      <path d="M180 188v48" stroke-width="10" />
+      <path d="M72 124h216" stroke-width="10" opacity="0.65" />
+      <path d="M72 164h92" stroke-width="10" opacity="0.45" />
+      <path d="M252 164h36" stroke-width="10" opacity="0.45" />
+      <path d="M316 40V8" stroke-width="10" />
+      <path d="M44 40V8" stroke-width="10" />
+    </g>
+    <g stroke="#E3C58A" stroke-linecap="round" stroke-width="12">
+      <path d="M0-198l128 344" />
+      <path d="M0-198L-128 146" />
+      <path d="M-42 40h84" />
+      <circle cx="0" cy="-198" r="22" fill="#E3C58A" stroke="none" />
+      <circle cx="-128" cy="146" r="18" fill="#E3C58A" stroke="none" />
+      <circle cx="128" cy="146" r="18" fill="#E3C58A" stroke="none" />
+    </g>
+  </g>
+</svg>

--- a/assets/palvelut/konsultointipalvelut-bg.svg
+++ b/assets/palvelut/konsultointipalvelut-bg.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 900" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="konsulttiPalette" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#21170E" />
+      <stop offset="100%" stop-color="#3A2A17" />
+    </linearGradient>
+    <pattern id="konsulttiDashes" width="120" height="120" patternUnits="userSpaceOnUse">
+      <path d="M0 60h120" stroke="#AA8E5A" stroke-opacity="0.12" stroke-width="8" stroke-linecap="round" />
+      <path d="M60 0v120" stroke="#AA8E5A" stroke-opacity="0.12" stroke-width="8" stroke-linecap="round" />
+    </pattern>
+    <filter id="konsulttiShadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#000" flood-opacity="0.42" />
+    </filter>
+  </defs>
+  <rect width="1200" height="900" fill="url(#konsulttiPalette)" />
+  <rect width="1200" height="900" fill="url(#konsulttiDashes)" />
+  <g transform="translate(600 450)">
+    <circle r="220" fill="#25190F" stroke="#F4E7D1" stroke-width="8" filter="url(#konsulttiShadow)" />
+    <g fill="none" stroke="#F4E7D1" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M-126 -40h252c32 0 58 24 58 54s-26 54-58 54h-40l24 72-104-72h-132c-32 0-58-24-58-54s26-54 58-54z" stroke-width="14" />
+      <path d="M-84 -20h168" stroke-width="12" opacity="0.7" />
+      <path d="M-60 16h120" stroke-width="12" opacity="0.55" />
+      <path d="M-38 52h76" stroke-width="12" opacity="0.4" />
+    </g>
+    <g>
+      <path d="M48 -124a86 86 0 0 1 86 86 86 86 0 0 1-86 86 86 86 0 0 1-38-9l-52 32 18-68a86 86 0 0 1 72-141z" fill="#E3C58A" opacity="0.92" />
+      <path d="M14 -32l34 34 74-74" fill="none" stroke="#25190F" stroke-width="16" stroke-linecap="round" stroke-linejoin="round" />
+    </g>
+    <g stroke="#E3C58A" stroke-width="12" stroke-linecap="round" stroke-linejoin="round" opacity="0.55">
+      <path d="M-200 -176h400" />
+      <path d="M-200 176h400" />
+      <path d="M-200 -176l200 112 200-112" />
+    </g>
+  </g>
+</svg>

--- a/assets/palvelut/rakennesuunnittelu-bg.svg
+++ b/assets/palvelut/rakennesuunnittelu-bg.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 900" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="rakennePalette" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1B120A" />
+      <stop offset="100%" stop-color="#362512" />
+    </linearGradient>
+    <pattern id="rakenneStruts" width="80" height="80" patternUnits="userSpaceOnUse">
+      <path d="M0 80L80 0M-20 40L40-20M40 100l60-60" fill="none" stroke="#9C814F" stroke-opacity="0.1" stroke-width="6" />
+    </pattern>
+    <filter id="rakenneShadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="20" stdDeviation="20" flood-color="#000" flood-opacity="0.45" />
+    </filter>
+  </defs>
+  <rect width="1200" height="900" fill="url(#rakennePalette)" />
+  <rect width="1200" height="900" fill="url(#rakenneStruts)" />
+  <g transform="translate(600 450)">
+    <circle r="220" fill="#24170C" stroke="#F2E2C4" stroke-width="8" filter="url(#rakenneShadow)" />
+    <g fill="none" stroke="#F2E2C4" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M-138 94h276" stroke-width="18" />
+      <path d="M-138 -128h276" stroke-width="18" />
+      <path d="M-110 -110V76" stroke-width="12" opacity="0.75" />
+      <path d="M110 -110V76" stroke-width="12" opacity="0.75" />
+      <path d="M-56 -110v186" stroke-width="12" opacity="0.55" />
+      <path d="M56 -110v186" stroke-width="12" opacity="0.55" />
+    </g>
+    <g fill="#E3C58A">
+      <path d="M-110 -128h220l-32-72h-156l-32 72z" opacity="0.9" />
+      <rect x="-88" y="-38" width="176" height="76" rx="16" />
+      <path d="M-110 94h220l36 86h-292l36-86z" opacity="0.9" />
+    </g>
+    <g stroke="#E3C58A" stroke-width="12" stroke-linecap="round" opacity="0.65">
+      <path d="M-180 -198h360" />
+      <path d="M-180 160h360" />
+      <path d="M-180 -198l180 118 180-118" />
+    </g>
+  </g>
+</svg>

--- a/assets/palvelut/rakennuttajapalvelut-bg.svg
+++ b/assets/palvelut/rakennuttajapalvelut-bg.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 900" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="rakennuttajaPalette" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#22170D" />
+      <stop offset="100%" stop-color="#3C2B17" />
+    </linearGradient>
+    <pattern id="rakennuttajaPattern" width="100" height="100" patternUnits="userSpaceOnUse">
+      <path d="M0 0h100v100H0z" fill="none" />
+      <path d="M0 50h100" stroke="#A68855" stroke-opacity="0.1" stroke-width="10" stroke-linecap="round" />
+      <path d="M50 0v100" stroke="#A68855" stroke-opacity="0.1" stroke-width="10" stroke-linecap="round" />
+      <circle cx="50" cy="50" r="8" fill="#A68855" opacity="0.18" />
+    </pattern>
+    <filter id="rakennuttajaShadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#000" flood-opacity="0.42" />
+    </filter>
+  </defs>
+  <rect width="1200" height="900" fill="url(#rakennuttajaPalette)" />
+  <rect width="1200" height="900" fill="url(#rakennuttajaPattern)" />
+  <g transform="translate(600 450)">
+    <circle r="220" fill="#261A10" stroke="#F4E7D1" stroke-width="8" filter="url(#rakennuttajaShadow)" />
+    <g>
+      <path d="M0 -156a110 110 0 0 1 110 110v18h-220v-18A110 110 0 0 1 0 -156z" fill="#E3C58A" />
+      <path d="M-98 -28h196v126c0 56-44 102-98 102s-98-46-98-102V-28z" fill="#F4E7D1" />
+      <path d="M-74 -24h148v80c0 40-33 72-74 72s-74-32-74-72v-80z" fill="#261A10" />
+      <path d="M0 -156c-40 0-86 22-110 48l24 40h172l24-40c-24-26-70-48-110-48z" fill="#261A10" opacity="0.8" />
+      <path d="M-48 -24v-22c0-26 22-48 48-48s48 22 48 48v22" fill="none" stroke="#261A10" stroke-width="12" stroke-linecap="round" />
+      <path d="M-48 60h96" stroke="#F4E7D1" stroke-width="18" stroke-linecap="round" opacity="0.8" />
+      <path d="M-26 108h52" stroke="#F4E7D1" stroke-width="14" stroke-linecap="round" opacity="0.65" />
+    </g>
+    <g stroke="#E3C58A" stroke-width="12" stroke-linecap="round" stroke-linejoin="round" opacity="0.58">
+      <path d="M-200 -176h400" />
+      <path d="M-200 176h400" />
+      <path d="M-200 -176l200 112 200-112" />
+      <path d="M-132 208h264l-24 80h-216l-24-80z" />
+    </g>
+  </g>
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,34 +2,43 @@ import { type ChangeEvent, type FormEvent, type MouseEvent, useEffect, useState 
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { CalendarCheck, ClipboardList, Mail, Megaphone, Menu, Phone, User, X } from 'lucide-react';
 import aurinkokuningasLogo from '../assets/aurinkokuningas.png';
+import arkkitehtisuunnitteluBackground from '../assets/palvelut/arkkitehtisuunnittelu-bg.svg';
+import konsultointipalvelutBackground from '../assets/palvelut/konsultointipalvelut-bg.svg';
+import rakennuttajapalvelutBackground from '../assets/palvelut/rakennuttajapalvelut-bg.svg';
+import rakennesuunnitteluBackground from '../assets/palvelut/rakennesuunnittelu-bg.svg';
 import Footer from './components/Footer';
 
 type Service = {
   title: string;
   desc: string;
   link?: string;
+  image: string;
 };
 
 const services: Service[] = [
   {
     title: 'Arkkitehtisuunnittelu',
     desc: '• Asemapiirustus\n\n• Pohjapiirustus\n\n• Leikkauspiirustukset\n\n• Julkisivukuvat',
-    link: '/arkkitehtisuunnittelu'
+    link: '/arkkitehtisuunnittelu',
+    image: arkkitehtisuunnitteluBackground
   },
   {
     title: 'Rakennesuunnittelu',
     desc: '• Turvalliset ja kestävät rakenteet kaikkiin kohteisiin\n\n• Ratkaisut, jotka tukevat arkkitehtisuunnittelua ja helpottavat työmaan toteutusta\n\n• Selkeät ja luotettavat rakennesuunnitelmat, jotka tekevät rakentamisesta sujuvampaa',
-    link: '/rakennesuunnittelu'
+    link: '/rakennesuunnittelu',
+    image: rakennesuunnitteluBackground
   },
   {
     title: 'Konsultointipalvelut',
     desc: '• Asiantuntevaa tukea rakennushankkeen eri vaiheisiin\n\n• Suunnitelmien arviointi ja kustannusarvioiden laadinta\n\n• Viranomaisasioiden hoitamisen neuvonta\n\n• Ratkaisut asiakkaan tarpeen mukaan\n\n• Päätöksenteon helpottaminen ja projektin selkeyttäminen',
-    link: '/konsultointipalvelut'
+    link: '/konsultointipalvelut',
+    image: konsultointipalvelutBackground
   },
   {
     title: 'Rakennuttajapalvelut',
     desc: '• Vastaavatyönjohtaja\n\n• Pääsuunnittelija\n\n• Rakennushankkeen hallinta alusta loppuun\n\n• Asiakkaan edunvalvonta koko projektin ajan\n\n• Vaivattomampi ja hallitumpi rakennusprosessi',
-    link: '/rakennuttajapalvelut'
+    link: '/rakennuttajapalvelut',
+    image: rakennuttajapalvelutBackground
   }
 ];
 
@@ -272,11 +281,14 @@ function App() {
               const ServiceBox = (
                 <div
                   key={index}
-                  className="group relative overflow-hidden rounded-xl border-2"
+                  className="group relative overflow-hidden rounded-xl border-2 transition-transform duration-500 ease-out hover:-translate-y-1"
                   style={{
-                    backgroundColor: '#FEF8EB',
+                    backgroundImage: `linear-gradient(160deg, rgba(33, 24, 16, 0.82), rgba(62, 51, 38, 0.55)), url(${service.image})`,
+                    backgroundSize: 'cover',
+                    backgroundPosition: 'center',
+                    backgroundRepeat: 'no-repeat',
                     border: '2px solid #C9972E',
-                    boxShadow: '0 4px 12px rgba(201, 151, 46, 0.15)',
+                    boxShadow: '0 4px 18px rgba(201, 151, 46, 0.25)',
                     cursor: service.link ? 'pointer' : 'default'
                   }}
                   onClick={() => handleServiceNavigation(service.link)}
@@ -292,14 +304,14 @@ function App() {
                   <div className="relative z-10 flex h-full flex-col gap-6 p-6 sm:p-8 lg:p-10">
                     <h3
                       className="text-xl sm:text-2xl font-bold"
-                      style={{ color: '#3E3326', lineHeight: '1.4', letterSpacing: '0.01em' }}
+                      style={{ color: '#FEF8EB', lineHeight: '1.4', letterSpacing: '0.01em' }}
                     >
                       {service.title}
                     </h3>
                     <p
                       className="text-base sm:text-lg"
                       style={{
-                        color: '#3E3326',
+                        color: '#FDF3E0',
                         whiteSpace: 'pre-line',
                         lineHeight: '1.8',
                         fontWeight: 400,
@@ -310,7 +322,7 @@ function App() {
                     </p>
                     {service.link && (
                       <span
-                        className="mt-auto inline-flex items-center text-sm font-semibold uppercase tracking-widest text-[#C9972E] transition-transform duration-200 group-hover:translate-x-1"
+                        className="mt-auto inline-flex items-center text-sm font-semibold uppercase tracking-widest text-[#FDE2AA] transition-transform duration-200 group-hover:translate-x-1"
                       >
                         Tutustu palveluun →
                       </span>


### PR DESCRIPTION
## Summary
- replace each Palvelut card background with a logo-style emblem that clearly signals its service focus
- add subtle structural patterns and drop shadows to frame the new iconography while keeping copy legible

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fa5d75998083218c9ea5c7d5c1810d