### PR TITLE
Create service backgrounds with niche architectural styling

### DIFF
--- a/assets/palvelut/arkkitehtisuunnittelu-bg.svg
+++ b/assets/palvelut/arkkitehtisuunnittelu-bg.svg
@@ -1,38 +1,24 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 900" preserveAspectRatio="xMidYMid slice">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 900" preserveAspectRatio="xMidYMid slice" role="img" aria-label="Tyylitelty arkkitehtipiirustusta muistuttava tausta">
   <defs>
-    <linearGradient id="arkkitehtiPalette" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#20160E" />
-      <stop offset="100%" stop-color="#3B2C1B" />
+    <linearGradient id="arkkitehtiBase" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#23170F" />
+      <stop offset="100%" stop-color="#342618" />
     </linearGradient>
-    <pattern id="arkkitehtiGrid" width="60" height="60" patternUnits="userSpaceOnUse">
-      <path d="M60 0H0v60" fill="none" stroke="#8D7452" stroke-opacity="0.12" stroke-width="2" />
+    <pattern id="arkkitehtiBlueprint" width="70" height="70" patternUnits="userSpaceOnUse">
+      <path d="M70 0H0v70" fill="none" stroke="#C7A15A" stroke-opacity="0.12" stroke-width="1.5" />
     </pattern>
-    <filter id="arkkitehtiShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#000" flood-opacity="0.4" />
-    </filter>
   </defs>
-  <rect width="1200" height="900" fill="url(#arkkitehtiPalette)" />
-  <rect width="1200" height="900" fill="url(#arkkitehtiGrid)" />
-  <g transform="translate(600 440)">
-    <circle r="220" fill="#2B1F13" stroke="#F4E7D1" stroke-width="8" filter="url(#arkkitehtiShadow)" />
-    <g transform="translate(-120 -120)" fill="none" stroke="#F4E7D1" stroke-linecap="round" stroke-linejoin="round">
-      <rect x="28" y="40" width="304" height="196" rx="26" stroke-width="14" />
-      <path d="M180 40v196" stroke-width="10" opacity="0.7" />
-      <path d="M180 80l74 52-74 52-74-52 74-52z" stroke-width="12" />
-      <path d="M180 188v48" stroke-width="10" />
-      <path d="M72 124h216" stroke-width="10" opacity="0.65" />
-      <path d="M72 164h92" stroke-width="10" opacity="0.45" />
-      <path d="M252 164h36" stroke-width="10" opacity="0.45" />
-      <path d="M316 40V8" stroke-width="10" />
-      <path d="M44 40V8" stroke-width="10" />
-    </g>
-    <g stroke="#E3C58A" stroke-linecap="round" stroke-width="12">
-      <path d="M0-198l128 344" />
-      <path d="M0-198L-128 146" />
-      <path d="M-42 40h84" />
-      <circle cx="0" cy="-198" r="22" fill="#E3C58A" stroke="none" />
-      <circle cx="-128" cy="146" r="18" fill="#E3C58A" stroke="none" />
-      <circle cx="128" cy="146" r="18" fill="#E3C58A" stroke="none" />
-    </g>
+  <rect width="1200" height="900" fill="url(#arkkitehtiBase)" />
+  <rect width="1200" height="900" fill="url(#arkkitehtiBlueprint)" />
+  <g transform="translate(600 460)" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="-250" y="-210" width="500" height="360" rx="42" stroke="#F5E6C8" stroke-width="10" />
+    <path d="M-250 -60H250" stroke="#F5E6C8" stroke-width="8" opacity="0.85" />
+    <path d="M-50 -210v360" stroke="#F5E6C8" stroke-width="8" opacity="0.85" />
+    <path d="M-50 -20l110 72-110 72-110-72 110-72z" stroke="#EBCB83" stroke-width="10" opacity="0.9" />
+    <circle cx="210" cy="-150" r="34" stroke="#EBCB83" stroke-width="8" opacity="0.75" />
+    <path d="M-190 -150h160" stroke="#EBCB83" stroke-width="8" opacity="0.6" />
+    <path d="M-190 40h120" stroke="#EBCB83" stroke-width="8" opacity="0.55" />
+    <path d="M60 120h140" stroke="#EBCB83" stroke-width="8" opacity="0.55" />
+    <rect x="70" y="-20" width="120" height="120" stroke="#F5E6C8" stroke-width="7" opacity="0.65" />
   </g>
 </svg>

--- a/assets/palvelut/konsultointipalvelut-bg.svg
+++ b/assets/palvelut/konsultointipalvelut-bg.svg
@@ -1,35 +1,36 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 900" preserveAspectRatio="xMidYMid slice">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 900" preserveAspectRatio="xMidYMid slice" role="img" aria-label="Tyylitelty konsultointia symboloiva tausta">
   <defs>
-    <linearGradient id="konsulttiPalette" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#21170E" />
-      <stop offset="100%" stop-color="#3A2A17" />
+    <linearGradient id="konsulttiBase" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#22170F" />
+      <stop offset="100%" stop-color="#332619" />
     </linearGradient>
-    <pattern id="konsulttiDashes" width="120" height="120" patternUnits="userSpaceOnUse">
-      <path d="M0 60h120" stroke="#AA8E5A" stroke-opacity="0.12" stroke-width="8" stroke-linecap="round" />
-      <path d="M60 0v120" stroke="#AA8E5A" stroke-opacity="0.12" stroke-width="8" stroke-linecap="round" />
-    </pattern>
-    <filter id="konsulttiShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#000" flood-opacity="0.42" />
-    </filter>
+    <radialGradient id="konsulttiGlow" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#F6E7C6" stop-opacity="0.2" />
+      <stop offset="100%" stop-color="#E3C27A" stop-opacity="0" />
+    </radialGradient>
   </defs>
-  <rect width="1200" height="900" fill="url(#konsulttiPalette)" />
-  <rect width="1200" height="900" fill="url(#konsulttiDashes)" />
-  <g transform="translate(600 450)">
-    <circle r="220" fill="#25190F" stroke="#F4E7D1" stroke-width="8" filter="url(#konsulttiShadow)" />
-    <g fill="none" stroke="#F4E7D1" stroke-linecap="round" stroke-linejoin="round">
-      <path d="M-126 -40h252c32 0 58 24 58 54s-26 54-58 54h-40l24 72-104-72h-132c-32 0-58-24-58-54s26-54 58-54z" stroke-width="14" />
-      <path d="M-84 -20h168" stroke-width="12" opacity="0.7" />
-      <path d="M-60 16h120" stroke-width="12" opacity="0.55" />
-      <path d="M-38 52h76" stroke-width="12" opacity="0.4" />
-    </g>
-    <g>
-      <path d="M48 -124a86 86 0 0 1 86 86 86 86 0 0 1-86 86 86 86 0 0 1-38-9l-52 32 18-68a86 86 0 0 1 72-141z" fill="#E3C58A" opacity="0.92" />
-      <path d="M14 -32l34 34 74-74" fill="none" stroke="#25190F" stroke-width="16" stroke-linecap="round" stroke-linejoin="round" />
-    </g>
-    <g stroke="#E3C58A" stroke-width="12" stroke-linecap="round" stroke-linejoin="round" opacity="0.55">
-      <path d="M-200 -176h400" />
-      <path d="M-200 176h400" />
-      <path d="M-200 -176l200 112 200-112" />
-    </g>
+  <rect width="1200" height="900" fill="url(#konsulttiBase)" />
+  <rect width="1200" height="900" fill="url(#konsulttiGlow)" />
+  <g fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M240 520c0-140 110-250 240-250h240c130 0 240 110 240 250" stroke="#F6E3BB" stroke-width="10" opacity="0.7" />
+    <path d="M360 560c0-90 70-160 160-160h160c90 0 160 70 160 160" stroke="#EBCB83" stroke-width="10" opacity="0.75" />
+  </g>
+  <g fill="none" stroke="#F5E6C8" stroke-width="12" stroke-linecap="round" stroke-linejoin="round" opacity="0.85">
+    <path d="M420 620h360l60 120H360l60-120z" />
+    <path d="M420 620v-110c0-44 36-80 80-80h200c44 0 80 36 80 80v110" />
+  </g>
+  <g fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.9">
+    <path d="M420 420c0-60 48-108 108-108h144c60 0 108 48 108 108" stroke="#F0D79D" stroke-width="10" />
+    <path d="M468 420c0-36 30-66 66-66h132c36 0 66 30 66 66" stroke="#EAC179" stroke-width="8" />
+  </g>
+  <g fill="none" stroke="#F5E6C8" stroke-width="8" opacity="0.8">
+    <path d="M460 460h280" />
+    <path d="M460 500h200" />
+    <path d="M460 540h140" />
+  </g>
+  <g fill="#EBCB83" opacity="0.85">
+    <circle cx="360" cy="560" r="20" />
+    <circle cx="840" cy="560" r="20" />
+    <circle cx="600" cy="356" r="18" />
   </g>
 </svg>

--- a/assets/palvelut/rakennesuunnittelu-bg.svg
+++ b/assets/palvelut/rakennesuunnittelu-bg.svg
@@ -1,37 +1,27 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 900" preserveAspectRatio="xMidYMid slice">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 900" preserveAspectRatio="xMidYMid slice" role="img" aria-label="Tyylitelty rakenneratkaisuja kuvaava tausta">
   <defs>
-    <linearGradient id="rakennePalette" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#1B120A" />
-      <stop offset="100%" stop-color="#362512" />
+    <linearGradient id="rakenneBase" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1E140C" />
+      <stop offset="100%" stop-color="#2D2115" />
     </linearGradient>
-    <pattern id="rakenneStruts" width="80" height="80" patternUnits="userSpaceOnUse">
-      <path d="M0 80L80 0M-20 40L40-20M40 100l60-60" fill="none" stroke="#9C814F" stroke-opacity="0.1" stroke-width="6" />
-    </pattern>
-    <filter id="rakenneShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="20" stdDeviation="20" flood-color="#000" flood-opacity="0.45" />
-    </filter>
+    <linearGradient id="beamHighlight" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#E8C47A" stop-opacity="0.4" />
+      <stop offset="100%" stop-color="#F6E3BB" stop-opacity="0.85" />
+    </linearGradient>
   </defs>
-  <rect width="1200" height="900" fill="url(#rakennePalette)" />
-  <rect width="1200" height="900" fill="url(#rakenneStruts)" />
-  <g transform="translate(600 450)">
-    <circle r="220" fill="#24170C" stroke="#F2E2C4" stroke-width="8" filter="url(#rakenneShadow)" />
-    <g fill="none" stroke="#F2E2C4" stroke-linecap="round" stroke-linejoin="round">
-      <path d="M-138 94h276" stroke-width="18" />
-      <path d="M-138 -128h276" stroke-width="18" />
-      <path d="M-110 -110V76" stroke-width="12" opacity="0.75" />
-      <path d="M110 -110V76" stroke-width="12" opacity="0.75" />
-      <path d="M-56 -110v186" stroke-width="12" opacity="0.55" />
-      <path d="M56 -110v186" stroke-width="12" opacity="0.55" />
-    </g>
-    <g fill="#E3C58A">
-      <path d="M-110 -128h220l-32-72h-156l-32 72z" opacity="0.9" />
-      <rect x="-88" y="-38" width="176" height="76" rx="16" />
-      <path d="M-110 94h220l36 86h-292l36-86z" opacity="0.9" />
-    </g>
-    <g stroke="#E3C58A" stroke-width="12" stroke-linecap="round" opacity="0.65">
-      <path d="M-180 -198h360" />
-      <path d="M-180 160h360" />
-      <path d="M-180 -198l180 118 180-118" />
-    </g>
+  <rect width="1200" height="900" fill="url(#rakenneBase)" />
+  <g stroke="#CFA554" stroke-opacity="0.2" stroke-width="2">
+    <path d="M0 160l1200 160M0 360l1200 160M0 560l1200 160" />
+    <path d="M160 0l160 900M440 0l160 900M720 0l160 900M1000 0l160 900" />
+  </g>
+  <g fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M160 620h880l60-120H100l60 120z" stroke="#F4E6C5" stroke-width="14" opacity="0.75" />
+    <path d="M240 500l120-220 160 320 160-320 120 220" stroke="#F0D79D" stroke-width="12" opacity="0.85" />
+    <path d="M160 620l120-120 160 120 160-120 160 120 120-120 100 120" stroke="#EAC179" stroke-width="10" opacity="0.8" />
+  </g>
+  <g fill="url(#beamHighlight)" fill-opacity="0.85" stroke="#3E2F20" stroke-width="3" opacity="0.75">
+    <rect x="220" y="260" width="160" height="36" rx="12" />
+    <rect x="510" y="260" width="180" height="36" rx="12" />
+    <rect x="820" y="260" width="160" height="36" rx="12" />
   </g>
 </svg>

--- a/assets/palvelut/rakennuttajapalvelut-bg.svg
+++ b/assets/palvelut/rakennuttajapalvelut-bg.svg
@@ -1,37 +1,39 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 900" preserveAspectRatio="xMidYMid slice">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 900" preserveAspectRatio="xMidYMid slice" role="img" aria-label="Tyylitelty rakennuttamisen hallintaa kuvaava tausta">
   <defs>
-    <linearGradient id="rakennuttajaPalette" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#22170D" />
-      <stop offset="100%" stop-color="#3C2B17" />
+    <linearGradient id="rakennuttajaBase" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#20160F" />
+      <stop offset="100%" stop-color="#322518" />
     </linearGradient>
-    <pattern id="rakennuttajaPattern" width="100" height="100" patternUnits="userSpaceOnUse">
-      <path d="M0 0h100v100H0z" fill="none" />
-      <path d="M0 50h100" stroke="#A68855" stroke-opacity="0.1" stroke-width="10" stroke-linecap="round" />
-      <path d="M50 0v100" stroke="#A68855" stroke-opacity="0.1" stroke-width="10" stroke-linecap="round" />
-      <circle cx="50" cy="50" r="8" fill="#A68855" opacity="0.18" />
-    </pattern>
-    <filter id="rakennuttajaShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#000" flood-opacity="0.42" />
-    </filter>
+    <linearGradient id="timelineGlow" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#E8C47A" stop-opacity="0.2" />
+      <stop offset="50%" stop-color="#F6E7C6" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#E8C47A" stop-opacity="0.2" />
+    </linearGradient>
   </defs>
-  <rect width="1200" height="900" fill="url(#rakennuttajaPalette)" />
-  <rect width="1200" height="900" fill="url(#rakennuttajaPattern)" />
-  <g transform="translate(600 450)">
-    <circle r="220" fill="#261A10" stroke="#F4E7D1" stroke-width="8" filter="url(#rakennuttajaShadow)" />
-    <g>
-      <path d="M0 -156a110 110 0 0 1 110 110v18h-220v-18A110 110 0 0 1 0 -156z" fill="#E3C58A" />
-      <path d="M-98 -28h196v126c0 56-44 102-98 102s-98-46-98-102V-28z" fill="#F4E7D1" />
-      <path d="M-74 -24h148v80c0 40-33 72-74 72s-74-32-74-72v-80z" fill="#261A10" />
-      <path d="M0 -156c-40 0-86 22-110 48l24 40h172l24-40c-24-26-70-48-110-48z" fill="#261A10" opacity="0.8" />
-      <path d="M-48 -24v-22c0-26 22-48 48-48s48 22 48 48v22" fill="none" stroke="#261A10" stroke-width="12" stroke-linecap="round" />
-      <path d="M-48 60h96" stroke="#F4E7D1" stroke-width="18" stroke-linecap="round" opacity="0.8" />
-      <path d="M-26 108h52" stroke="#F4E7D1" stroke-width="14" stroke-linecap="round" opacity="0.65" />
-    </g>
-    <g stroke="#E3C58A" stroke-width="12" stroke-linecap="round" stroke-linejoin="round" opacity="0.58">
-      <path d="M-200 -176h400" />
-      <path d="M-200 176h400" />
-      <path d="M-200 -176l200 112 200-112" />
-      <path d="M-132 208h264l-24 80h-216l-24-80z" />
-    </g>
+  <rect width="1200" height="900" fill="url(#rakennuttajaBase)" />
+  <g stroke="#CFA554" stroke-opacity="0.18" stroke-width="2">
+    <path d="M0 240h1200M0 460h1200M0 680h1200" />
+    <path d="M200 0v900M460 0v900M720 0v900M980 0v900" />
+  </g>
+  <g fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.85">
+    <path d="M200 620h800" stroke="url(#timelineGlow)" stroke-width="26" />
+    <path d="M260 500l120-160 140 200 140-200 120 160 120-120 100 140" stroke="#F4E6C5" stroke-width="12" />
+    <path d="M260 720h180l60-120 120 200 120-200 80 120h140" stroke="#EBCB83" stroke-width="10" />
+  </g>
+  <g fill="#F5E6C8" opacity="0.9" stroke="#3E2F20" stroke-width="3">
+    <circle cx="260" cy="620" r="22" />
+    <circle cx="460" cy="620" r="22" />
+    <circle cx="640" cy="620" r="22" />
+    <circle cx="820" cy="620" r="22" />
+    <circle cx="1000" cy="620" r="22" />
+  </g>
+  <g fill="none" stroke="#F0D79D" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" opacity="0.85">
+    <rect x="280" y="280" width="160" height="120" rx="18" />
+    <rect x="520" y="320" width="180" height="120" rx="18" />
+    <path d="M560 350h60" />
+    <path d="M560 390h100" />
+    <rect x="800" y="280" width="160" height="140" rx="22" />
+    <path d="M820 320h120" />
+    <path d="M820 360h80" />
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- redesign the service card background illustrations with modern, niche-specific motifs
- add accessible metadata and simplified blueprint, structure, consulting, and project-management visuals for each SVG

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fa711cad848321b94f1781d1fea9f8