### PR TITLE
Replace Venevaja project art with SVG illustration

### DIFF
--- a/public/venevaja.svg
+++ b/public/venevaja.svg
@@ -1,0 +1,71 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-labelledby="title desc">
+  <title id="title">Stylized illustration of a boat house by the water</title>
+  <desc id="desc">Minimal illustration showing a timber boat house with a dark pitched roof sitting by a calm shoreline at sunset.</desc>
+  <defs>
+    <linearGradient id="skyGradient" x1="0%" x2="0%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#fef3d7" />
+      <stop offset="60%" stop-color="#f9d9a2" />
+      <stop offset="100%" stop-color="#f7c078" />
+    </linearGradient>
+    <linearGradient id="waterGradient" x1="0%" x2="0%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#7ac5e5" />
+      <stop offset="100%" stop-color="#2b6f9b" />
+    </linearGradient>
+    <linearGradient id="roofGradient" x1="0%" x2="100%" y1="0%" y2="0%">
+      <stop offset="0%" stop-color="#2f3a47" />
+      <stop offset="100%" stop-color="#111720" />
+    </linearGradient>
+    <linearGradient id="wallGradient" x1="0%" x2="0%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#f5d9b4" />
+      <stop offset="100%" stop-color="#d7ab6a" />
+    </linearGradient>
+    <linearGradient id="doorGradient" x1="0%" x2="0%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#b66534" />
+      <stop offset="100%" stop-color="#7c3f1a" />
+    </linearGradient>
+    <linearGradient id="reflectionGradient" x1="0%" x2="0%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#c3e7f7" stop-opacity="0.6" />
+      <stop offset="100%" stop-color="#6eb3d6" stop-opacity="0.15" />
+    </linearGradient>
+  </defs>
+
+  <rect width="1200" height="800" fill="url(#skyGradient)" />
+
+  <g opacity="0.55">
+    <circle cx="200" cy="160" r="90" fill="#fee4ac" />
+    <circle cx="170" cy="190" r="40" fill="#ffe4b3" />
+    <circle cx="240" cy="210" r="30" fill="#ffd6a0" />
+  </g>
+
+  <rect y="520" width="1200" height="280" fill="url(#waterGradient)" />
+  <rect y="500" width="1200" height="80" fill="#e8c28b" />
+
+  <g transform="translate(260,280)">
+    <polygon points="0,220 340,40 680,220" fill="url(#roofGradient)" />
+    <rect x="40" y="220" width="600" height="240" fill="url(#wallGradient)" />
+    <rect x="220" y="280" width="200" height="180" fill="url(#doorGradient)" rx="8" />
+    <rect x="110" y="300" width="70" height="120" fill="#ede1ce" />
+    <rect x="500" y="300" width="70" height="120" fill="#ede1ce" />
+    <rect x="260" y="320" width="120" height="20" fill="#f2ede4" opacity="0.8" />
+
+    <path d="M-40 480 Q340 430 720 480 L720 520 L-40 520 Z" fill="#b47b3c" />
+  </g>
+
+  <g transform="translate(260,540)" opacity="0.65">
+    <path d="M-40 0 Q340 -50 720 0 L720 160 L-40 160 Z" fill="url(#reflectionGradient)" />
+    <rect x="80" y="0" width="120" height="90" fill="#ffffff" opacity="0.35" />
+    <rect x="460" y="0" width="120" height="90" fill="#ffffff" opacity="0.35" />
+    <rect x="260" y="20" width="160" height="70" fill="#ffffff" opacity="0.15" />
+  </g>
+
+  <g fill="#ffffff" opacity="0.8">
+    <path d="M900 560 c50 -30 120 -30 160 0" stroke="#ffffff" stroke-width="6" fill="none" stroke-linecap="round" />
+    <path d="M910 600 c40 -24 100 -24 140 0" stroke="#ffffff" stroke-width="5" fill="none" stroke-linecap="round" />
+  </g>
+
+  <g fill="#fefefe" opacity="0.6">
+    <circle cx="1020" cy="180" r="7" />
+    <circle cx="1080" cy="210" r="5" />
+    <circle cx="960" cy="230" r="6" />
+  </g>
+</svg>

--- a/src/ProjektitPage.tsx
+++ b/src/ProjektitPage.tsx
@@ -36,7 +36,7 @@ function ProjektitPage() {
         'Käytännöllinen pohjaratkaisu',
         'Yhdistyy ympäristöön harmonisesti'
       ],
-      image: '/venevaja.jpg'
+      image: '/venevaja.svg'
     },
     {
       title: 'Varasto',
@@ -119,7 +119,7 @@ function ProjektitPage() {
                     <img
                       src={project.image}
                       alt={project.title}
-                      className="w-full h-full object-cover"
+                      className="w-full h-full object-cover object-center"
                       onError={(e) => {
                         const target = e.target as HTMLImageElement;
                         target.style.display = 'none';


### PR DESCRIPTION
## Summary
- remove the large binary PNG that GitHub could not preview
- add a lightweight SVG illustration for the Venevaja project card
- point the Venevaja card to the new vector asset so it keeps the same presentation as the other cards

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6905024c93088321859ed7f97c15fd6f