### PR TITLE
Align konsultointipalvelut service card background

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,6 @@ import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { CalendarCheck, ClipboardList, Mail, Megaphone, Menu, Phone, User, X } from 'lucide-react';
 import aurinkokuningasLogo from './assets/aurinkokuningasLogo';
 import arkkitehtisuunnitteluBackground from './assets/arkkitehtisuunnitteluBackground';
-import konsultointipalvelutBackground from './assets/konsultointipalvelutBackground';
 import rakennuttajapalvelutBackground from './assets/rakennuttajapalvelutBackground';
 import rakennesuunnitteluBackground from './assets/rakennesuunnitteluBackground';
 import Footer from './components/Footer';
@@ -32,7 +31,7 @@ const services: Service[] = [
     title: 'Konsultointipalvelut',
     desc: '• Asiantuntevaa tukea rakennushankkeen eri vaiheisiin\n\n• Suunnitelmien arviointi ja kustannusarvioiden laadinta\n\n• Viranomaisasioiden hoitamisen neuvonta\n\n• Ratkaisut asiakkaan tarpeen mukaan\n\n• Päätöksenteon helpottaminen ja projektin selkeyttäminen',
     link: '/konsultointipalvelut',
-    image: konsultointipalvelutBackground
+    image: arkkitehtisuunnitteluBackground
   },
   {
     title: 'Rakennuttajapalvelut',

--- a/src/assets/konsultointipalvelutBackground.ts
+++ b/src/assets/konsultointipalvelutBackground.ts
@@ -1,7 +1,0 @@
-// Konsultointipalvelut reuses the same background as Arkkitehtisuunnittelu to ensure
-// consistent appearance when the service card is opened.
-import arkkitehtisuunnitteluBackground from './arkkitehtisuunnitteluBackground';
-
-const konsultointipalvelutBackground = arkkitehtisuunnitteluBackground;
-
-export default konsultointipalvelutBackground;


### PR DESCRIPTION
## Summary
- update the konsultointipalvelut service card to use the same background asset as arkkitehtisuunnittelu
- remove the redundant konsultointipalvelut background module that only re-exported the shared image

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6905d2a4a3988321bd54716332b7474e